### PR TITLE
fix(workbooks) Updated Comply and Discover Workbook Visualizations

### DIFF
--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -296,7 +296,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "TaniumComplyVulnerabilities_CL\n|join kind=inner TaniumMainAsset_CL on Computer_Name_s\n|distinct CVE_s,Computer_Name_s,CVSS_Score_d, Operating_System_Generation_s\n|summarize  CVECount=dcount(CVE_s), cvss_endpoint_score=sum(todecimal(CVSS_Score_d)) by Computer_Name_s, Operating_System_Generation_s\n|project cvss_endpoint_score, CVECount, Computer_Name_s, Operating_System_Generation_s\n|render scatterchart\n|sort by cvss_endpoint_score asc",
+              "query": "TaniumComplyVulnerabilities_CL\n|distinct CVE_s,Computer_Name_s,CVSS_Score_d, Operating_System_Generation_s\n|summarize  CVECount=dcount(CVE_s), cvss_endpoint_score=sum(todecimal(CVSS_Score_d)) by Computer_Name_s, Operating_System_Generation_s\n|project cvss_endpoint_score, CVECount, Computer_Name_s, Operating_System_Generation_s\n|render scatterchart\n|sort by cvss_endpoint_score asc",
               "size": 0,
               "timeContext": {
                 "durationMs": 604800000

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -61,7 +61,7 @@
           {
             "type": 1,
             "content": {
-              "json": "## Top 10 mission critical computers with CVSS v3 hits >= 9.0"
+              "json": "## Top 10 mission critical computers with CVSS hits >= 9.0\n#### Based on CVE v3"
             },
             "name": "visualization title"
           },
@@ -132,7 +132,7 @@
           {
             "type": 1,
             "content": {
-              "json": "## Top operating systems with CVSS hits >= 9.0"
+              "json": "## Operating Systems with CVSS hits >= 9.0 by CVSS Count\n#### Based on CVE v3"
             },
             "name": "visualization title"
           },
@@ -219,7 +219,7 @@
           {
             "type": 1,
             "content": {
-              "json": "## Vulnerability Distribution by Severity"
+              "json": "## Vulnerability Distribution by Severity\n#### Based on CVE v3"
             },
             "name": "visualization title"
           },

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -205,7 +205,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "TaniumComplyVulnerabilities_CL\n|distinct CVE_s, Computer_Name_s, Operating_System_Generation_s\n|summarize count() by Operating_System_Generation_s",
+              "query": "TaniumComplyVulnerabilities_CL\n|where Scan_Type_s != 'container registries'\n|distinct CVE_s, Computer_Name_s, Operating_System_Generation_s\n|summarize count() by Operating_System_Generation_s",
               "size": 0,
               "timeContext": {
                 "durationMs": 2592000000

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -132,7 +132,7 @@
           {
             "type": 1,
             "content": {
-              "json": "## Operating Systems with CVSS hits >= 9.0 by CVSS Count\n#### Based on CVE v3"
+              "json": "## Top 10 mission critical computers with CVSS v3 hits >= 9.0\n#### Based on CVE v3"
             },
             "name": "visualization title"
           },

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -69,7 +69,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "let lastRunTime = toscalar(\n    TaniumComplyVulnerabilities_CL\n    | extend roundedTime = bin(TimeGenerated, 1m)\n    | distinct roundedTime\n    | order by roundedTime desc \n    | limit 1\n);\n\nTaniumComplyVulnerabilities_CL \n| where TimeGenerated >= lastRunTime and Computer_Name_s != "" and CVSS_Score_d >=9.0\n| extend Host_0_HostName = Computer_Name_s\n| extend Malware_0_Name = CVE_s\n| extend IP_0_Address = IP_Address_s\n| summarize count() by Computer_Name_s \n| sort by count_\n",
+              "query": "let lastRunTime = toscalar(\n    TaniumComplyVulnerabilities_CL\n    | extend roundedTime = bin(TimeGenerated, 1m) \n    | distinct roundedTime    \n    | order by roundedTime desc     \n    | limit 1);\n\nTaniumComplyVulnerabilities_CL \n| where Scan_Type_s != 'container registries' \n    and TimeGenerated >= lastRunTime\n    and CVSS_Score_d >=9.0\n| extend Host_0_HostName = Computer_Name_s\n| extend Malware_0_Name = CVE_s\n| extend IP_0_Address = IP_Address_s\n| summarize count() by Computer_Name_s \n| sort by count_",
               "size": 4,
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces",

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -175,7 +175,7 @@
           {
             "type": 1,
             "content": {
-              "json": "## Vulnerability distribution by year"
+              "json": "## Vulnerability Distribution by year"
             },
             "name": "visualization title"
           },
@@ -183,13 +183,14 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "TaniumComplyVulnerabilities_CL\n|distinct CVE_Year_s,Computer_Name_s, CVE_s\n|summarize count() by CVE_Year_s\n|render barchart  \n|sort by CVE_Year_s asc",
+              "query": "TaniumComplyVulnerabilities_CL\n|distinct CVE_Year_s,Computer_Name_s, CVE_s\n|summarize count() by CVE_Year_s \n|sort by CVE_Year_s asc",
               "size": 0,
               "timeContext": {
                 "durationMs": 2592000000
               },
               "queryType": 0,
-              "resourceType": "microsoft.operationalinsights/workspaces"
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "barchart"
             },
             "name": "query - 3"
           },
@@ -204,13 +205,14 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "TaniumComplyVulnerabilities_CL\n|distinct CVE_s, Computer_Name_s, Operating_System_Generation_s\n|summarize count() by Operating_System_Generation_s\n|render barchart",
+              "query": "TaniumComplyVulnerabilities_CL\n|distinct CVE_s, Computer_Name_s, Operating_System_Generation_s\n|summarize count() by Operating_System_Generation_s",
               "size": 0,
               "timeContext": {
                 "durationMs": 2592000000
               },
               "queryType": 0,
-              "resourceType": "microsoft.operationalinsights/workspaces"
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "barchart"
             },
             "name": "query - 4"
           },

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -381,7 +381,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "TaniumComplyCompliance_CL\n|where  Rule_ID_s != '\\\\'\n|summarize  Total=count(), Pass=countif(Status_Category_s has 'Pass'), Fail=countif(Status_Category_s has 'Fail')\n|extend PassRate=(Pass*1.0/Total)*100\n|project PassRate",
+              "query": "TaniumComplyCompliance_CL\n|where  Rule_ID_s != '\\\\'\nand Rule_ID_s != '[no results]'\n|summarize  Total=count(), Pass=countif(Status_Category_s has 'Pass'), Fail=countif(Status_Category_s has 'Fail')\n|extend PassRate=(Pass*1.0/Total)*100\n|project PassRate\n",
               "size": 1,
               "timeContext": {
                 "durationMs": 604800000

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -290,13 +290,13 @@
             "content": {
               "json": "## System Outliers (Based on CVE Count & Aggregate CVSS Score)\n"
             },
-            "name": "text - 14"
+            "name": "visualization title"
           },
           {
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "TaniumComplyVulnerabilities_CL\n|join kind=inner TaniumMainAsset_CL on Computer_Name_s\n|distinct CVE_s,Computer_Name_s,CVSS_Score_s, Operating_System_Generation_s\n|summarize  CVECount=dcount(CVE_s), cvss_endpoint_score=sum(todecimal(CVSS_Score_s)) by Computer_Name_s, Operating_System_Generation_s\n|project cvss_endpoint_score, CVECount, Computer_Name_s, Operating_System_Generation_s\n|render scatterchart\n|sort by cvss_endpoint_score asc",
+              "query": "TaniumComplyVulnerabilities_CL\n|join kind=inner TaniumMainAsset_CL on Computer_Name_s\n|distinct CVE_s,Computer_Name_s,CVSS_Score_d, Operating_System_Generation_s\n|summarize  CVECount=dcount(CVE_s), cvss_endpoint_score=sum(todecimal(CVSS_Score_d)) by Computer_Name_s, Operating_System_Generation_s\n|project cvss_endpoint_score, CVECount, Computer_Name_s, Operating_System_Generation_s\n|render scatterchart\n|sort by cvss_endpoint_score asc",
               "size": 0,
               "timeContext": {
                 "durationMs": 604800000

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -205,7 +205,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "TaniumComplyVulnerabilities_CL\n|where Scan_Type_s != 'container registries'\n|distinct CVE_s, Computer_Name_s, Operating_System_Generation_s\n|summarize count() by Operating_System_Generation_s",
+              "query": "let lastRunTime = toscalar(\n    TaniumComplyVulnerabilities_CL\n    | extend roundedTime = bin(TimeGenerated, 1m) \n    | distinct roundedTime    \n    | order by roundedTime desc     \n    | limit 1);\n    \n    \nTaniumComplyVulnerabilities_CL\n|where TimeGenerated >= lastRunTime\n    and Scan_Type_s != 'container registries'\n|distinct CVE_s, Computer_Name_s, Operating_System_Generation_s\n|summarize count() by Operating_System_Generation_s",
               "size": 0,
               "timeContext": {
                 "durationMs": 2592000000

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -132,7 +132,7 @@
           {
             "type": 1,
             "content": {
-              "json": "## Top 10 mission critical computers with CVSS v3 hits >= 9.0\n#### Based on CVE v3"
+              "json": "## Operating Systems with CVSS hits >= 9.0 by CVSS Count\n#### Based on CVE v3"
             },
             "name": "visualization title"
           },

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -50,7 +50,7 @@
           }
         ]
       },
-      "name": "links - 8"
+      "name": "horizontal tabs"
     },
     {
       "type": 12,
@@ -63,13 +63,13 @@
             "content": {
               "json": "## Top mission critical computers with CVSS hits >= 9.0"
             },
-            "name": "text - 2"
+            "name": "visualization title"
           },
           {
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "TaniumComplyVulnerabilities_CL \n| join TaniumMainAsset_CL on Computer_Name_s| where CVSS_Score_s startswith \"9\"\n| extend Host_0_HostName = Computer_Name_s\n| extend Malware_0_Name = CVE_s\n| extend IP_0_Address = IP_Address_s\n| summarize count() by Computer_Name_s | limit 4\n| sort by count_\n",
+              "query": "TaniumComplyVulnerabilities_CL \n| join TaniumMainAsset_CL on Computer_Name_s| where CVSS_Score_d >=9.0\n| extend Host_0_HostName = Computer_Name_s\n| extend Malware_0_Name = CVE_s\n| extend IP_0_Address = IP_Address_s\n| summarize count() by Computer_Name_s | limit 4\n| sort by count_\n",
               "size": 4,
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces",

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -290,7 +290,7 @@
           {
             "type": 1,
             "content": {
-              "json": "## System Outliers\n#### Based on CVE (v3) Count & Aggregate CVSS Score\n"
+              "json": "## System Outliers\n#### Based on CVE (v3) Count & Aggregate CVSS Score"
             },
             "name": "visualization title"
           },
@@ -381,7 +381,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "TaniumComplyCompliance_CL\n|where  Rule_ID_s != '\\\\'\nand Rule_ID_s != '[no results]'\n|summarize  Total=count(), Pass=countif(Status_Category_s has 'Pass'), Fail=countif(Status_Category_s has 'Fail')\n|extend PassRate=(Pass*1.0/Total)*100\n|project PassRate\n",
+              "query": "TaniumComplyCompliance_CL\n|where  Rule_ID_s != '\\\\'\nand Rule_ID_s != '[no results]'\n|summarize  Total=count(), Pass=countif(Status_Category_s has 'Pass'), Fail=countif(Status_Category_s has 'Fail')\n|extend PassRate=(Pass*1.0/Total)*100\n|project PassRate",
               "size": 1,
               "timeContext": {
                 "durationMs": 604800000
@@ -394,7 +394,14 @@
                   "columnMatch": "PassRate",
                   "formatter": 12,
                   "formatOptions": {
-                    "palette": "redBright"
+                    "palette": "redGreen"
+                  },
+                  "numberFormat": {
+                    "unit": 1,
+                    "options": {
+                      "style": "decimal",
+                      "maximumFractionDigits": 0
+                    }
                   }
                 },
                 "showBorder": false

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -298,7 +298,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "TaniumComplyVulnerabilities_CL\n|where Scan_Type_s != 'container registries' and CVSS_v3_Severity_s != 'Unscored'\n|distinct CVE_s,Computer_Name_s,CVSS_v3_Score_d, Operating_System_Generation_s\n|summarize  CVECount=dcount(CVE_s), cvss_endpoint_score=sum(todecimal(CVSS_v3_Score_d)) by Computer_Name_s, Operating_System_Generation_s\n|project cvss_endpoint_score, CVECount, Computer_Name_s, Operating_System_Generation_s\n|sort by cvss_endpoint_score asc",
+              "query": "TaniumComplyVulnerabilities_CL\n|where Scan_Type_s != 'container registries' and CVSS_v3_Severity_s != 'Unscored'\n|distinct CVE_s,Computer_Name_s,CVSS_v3_Score_d, Operating_System_Generation_s\n|summarize  CVECount=dcount(CVE_s), cvss_endpoint_score=sum(todecimal(CVSS_v3_Score_d)) by Computer_Name_s, Operating_System_Generation_s\n|sort by cvss_endpoint_score asc",
               "size": 0,
               "timeContext": {
                 "durationMs": 604800000

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -175,7 +175,7 @@
           {
             "type": 1,
             "content": {
-              "json": "## Vulnerability Distribution by year"
+              "json": "## Vulnerability Distribution by Year"
             },
             "name": "visualization title"
           },
@@ -183,7 +183,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "TaniumComplyVulnerabilities_CL\n|distinct CVE_Year_s,Computer_Name_s, CVE_s\n|summarize count() by CVE_Year_s \n|sort by CVE_Year_s asc",
+              "query": "let getCveYear = (s:string) { substring(s, 4, 4) };\nlet checkCveYearExists = (s:string) { iff(s startswith 'CVE-', getCveYear(s), 'Not Specified') };\nlet extractCveYear = (year:string,cve:string) { iff(year != '', year, checkCveYearExists(cve)) };\n\nlet Vulnerabilities = \nTaniumComplyVulnerabilities_CL\n| extend ParsedCveYear = extractCveYear(CVE_Year_s, CVE_s);\n\nVulnerabilities\n|distinct ParsedCveYear,Computer_Name_s, CVE_s\n|summarize count() by ParsedCveYear\n|sort by ParsedCveYear asc",
               "size": 0,
               "timeContext": {
                 "durationMs": 2592000000

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -445,7 +445,7 @@
             "content": {
               "json": "## Unmanaged OS Platform\n"
             },
-            "name": "text - 0"
+            "name": "visualization title"
           },
           {
             "type": 3,
@@ -460,14 +460,14 @@
               "resourceType": "microsoft.operationalinsights/workspaces",
               "visualization": "piechart"
             },
-            "name": "query - 1"
+            "name": "visualization title"
           },
           {
             "type": 1,
             "content": {
               "json": "## Unmanaged Device Type"
             },
-            "name": "text - 2"
+            "name": "visualization title"
           },
           {
             "type": 3,
@@ -489,7 +489,7 @@
             "content": {
               "json": "## Unmanaged Open Ports"
             },
-            "name": "text - 4"
+            "name": "visualization title"
           },
           {
             "type": 3,
@@ -511,13 +511,13 @@
             "content": {
               "json": "## All Unmanaged Assets"
             },
-            "name": "text - 6"
+            "name": "visualization title"
           },
           {
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "TaniumDiscoverUnmanagedAssets_CL\n| where HostName_s <> \"\"\n| project Hostname=HostName_s, MacAddres=MacAddress_s, IPAddress, MacOrganization=MacOrganization_s, LastDiscoveredTime=LastDiscoveredAt_s\n| sort by LastDiscoveredTime",
+              "query": "TaniumDiscoverUnmanagedAssets_CL\n| where HostName_s <> \"\"\n| project Hostname=HostName_s, MacAddres=MacAddress_s, IPAddress, MacOrganization=MacOrganization_s, LastDiscoveredTime=LastDiscoveredAt_t\n| sort by LastDiscoveredTime",
               "size": 0,
               "timeContext": {
                 "durationMs": 86400000

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -290,7 +290,7 @@
           {
             "type": 1,
             "content": {
-              "json": "## System Outliers (Based on CVE Count & Aggregate CVSS Score)\n"
+              "json": "## System Outliers\n#### Based on CVE Count & Aggregate CVSS Score\n"
             },
             "name": "visualization title"
           },
@@ -298,7 +298,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "TaniumComplyVulnerabilities_CL\n|distinct CVE_s,Computer_Name_s,CVSS_Score_d, Operating_System_Generation_s\n|summarize  CVECount=dcount(CVE_s), cvss_endpoint_score=sum(todecimal(CVSS_Score_d)) by Computer_Name_s, Operating_System_Generation_s\n|project cvss_endpoint_score, CVECount, Computer_Name_s, Operating_System_Generation_s\n|render scatterchart\n|sort by cvss_endpoint_score asc",
+              "query": "TaniumComplyVulnerabilities_CL\n|distinct CVE_s,Computer_Name_s,CVSS_Score_d, Operating_System_Generation_s\n|summarize  CVECount=dcount(CVE_s), cvss_endpoint_score=sum(todecimal(CVSS_Score_d)) by Computer_Name_s, Operating_System_Generation_s\n|project cvss_endpoint_score, CVECount, Computer_Name_s, Operating_System_Generation_s\n|sort by cvss_endpoint_score asc",
               "size": 0,
               "timeContext": {
                 "durationMs": 604800000

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -381,7 +381,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "TaniumComplyCompliance_CL | where  Rule_ID_s <> \"\"\n|summarize  Total=count(), Pass=countif(Status_Category_s has \"Pass\"), Fail=countif(Status_Category_s has \"Fail\")\n|extend PassRate=(Pass*1.0/Total)*100\n|project PassRate",
+              "query": "TaniumComplyCompliance_CL\n|where  Rule_ID_s != '\\\\'\n|summarize  Total=count(), Pass=countif(Status_Category_s has 'Pass'), Fail=countif(Status_Category_s has 'Fail')\n|extend PassRate=(Pass*1.0/Total)*100\n|project PassRate",
               "size": 1,
               "timeContext": {
                 "durationMs": 604800000

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -61,7 +61,7 @@
           {
             "type": 1,
             "content": {
-              "json": "## Top mission critical computers with CVSS v3 hits >= 9.0"
+              "json": "## Top 10 mission critical computers with CVSS v3 hits >= 9.0"
             },
             "name": "visualization title"
           },
@@ -69,7 +69,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "let lastRunTime = toscalar(\n    TaniumComplyVulnerabilities_CL\n    | extend roundedTime = bin(TimeGenerated, 1m) \n    | distinct roundedTime    \n    | order by roundedTime desc     \n    | limit 1);\n\nTaniumComplyVulnerabilities_CL \n| where Scan_Type_s != 'container registries' \n    and TimeGenerated >= lastRunTime\n    and CVSS_v3_Score_d >=9.0\n| extend Host_0_HostName = Computer_Name_s\n| extend Malware_0_Name = CVE_s\n| extend IP_0_Address = IP_Address_s\n| summarize count() by Computer_Name_s \n| sort by count_",
+              "query": "let lastRunTime = toscalar(\n    TaniumComplyVulnerabilities_CL\n    | extend roundedTime = bin(TimeGenerated, 1m) \n    | distinct roundedTime    \n    | order by roundedTime desc     \n    | limit 1);\n\nTaniumComplyVulnerabilities_CL \n| where Scan_Type_s != 'container registries'\n    and TimeGenerated >= lastRunTime\n    and CVSS_v3_Score_d >=9.0\n| extend Host_0_HostName = Computer_Name_s\n| extend Malware_0_Name = CVE_s\n| extend IP_0_Address = IP_Address_s\n| summarize count() by Computer_Name_s \n| limit 10\n| sort by count_",
               "size": 4,
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces",

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -504,7 +504,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "\nTaniumDiscoverUnmanagedAssets_CL\n|where Ports_s != '' \n|distinct MacAddress_s,Ports_s\n|summarize count() by Ports_s\n",
+              "query": "let lastRunTime = toscalar(\n    TaniumDiscoverUnmanagedAssets_CL\n    | extend roundedTime = bin(TimeGenerated, 1m) \n    | distinct roundedTime    \n    | order by roundedTime desc     \n    | limit 1);\n\nTaniumDiscoverUnmanagedAssets_CL\n|where TimeGenerated >= lastRunTime\n    and Ports_s != '' \n|distinct MacAddress_s,Ports_s\n|summarize count() by Ports_s",
               "size": 0,
               "timeContext": {
                 "durationMs": 2592000000

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -504,7 +504,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "let lastRunTime = toscalar(\n    TaniumDiscoverUnmanagedAssets_CL\n    | extend roundedTime = bin(TimeGenerated, 1m) \n    | distinct roundedTime    \n    | order by roundedTime desc     \n    | limit 1);\n\nTaniumDiscoverUnmanagedAssets_CL\n|where TimeGenerated >= lastRunTime\n    and Ports_s != '' \n|distinct MacAddress_s,Ports_s\n|summarize count() by Ports_s",
+              "query": "let lastRunTime = toscalar(\n    TaniumDiscoverUnmanagedAssets_CL\n    | extend roundedTime = bin(TimeGenerated, 1m) \n    | distinct roundedTime    \n    | order by roundedTime desc     \n    | limit 1);\n\nTaniumDiscoverUnmanagedAssets_CL\n| where TimeGenerated >= lastRunTime\n    and Ports_s != '' \n| distinct MacAddress_s,Ports_s\n| extend dPort = parse_json(strcat('[', Ports_s, ']'))\n| mv-expand  dPort\n| extend Port = tostring(dPort)\n| project MacAddress_s, Port\n| summarize count() by Port;",
               "size": 0,
               "timeContext": {
                 "durationMs": 2592000000

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -140,7 +140,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "TaniumComplyVulnerabilities_CL \n| join TaniumMainAsset_CL on Computer_Name_s| where CVSS_v3_Score_d >=9.0 \n| extend Host_0_HostName = Computer_Name_s\n| extend Malware_0_Name = CVE_s\n| extend IP_0_Address = IP_Address_s\n| summarize count() by Operating_System_Generation_s\n| sort by count_",
+              "query": "TaniumComplyVulnerabilities_CL \n| where CVSS_v3_Score_d >=9.0 \n| extend Host_0_HostName = Computer_Name_s\n| extend Malware_0_Name = CVE_s\n| extend IP_0_Address = IP_Address_s\n| summarize count() by Operating_System_Generation_s\n| sort by count_",
               "size": 4,
               "timeContext": {
                 "durationMs": 2592000000

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -381,7 +381,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "TaniumComplyCompliance_CL\n|where  Rule_ID_s != '\\\\'\nand Rule_ID_s != '[no results]'\n|summarize  Total=count(), Pass=countif(Status_Category_s has 'Pass'), Fail=countif(Status_Category_s has 'Fail')\n|extend PassRate=(Pass*1.0/Total)*100\n|project PassRate",
+              "query": "TaniumComplyCompliance_CL\n|where  Rule_ID_s != ''\nand Rule_ID_s != '[no results]'\n|summarize  Total=count(), Pass=countif(Status_Category_s has 'Pass'), Fail=countif(Status_Category_s has 'Fail')\n|extend PassRate=(Pass*1.0/Total)*100\n|project PassRate",
               "size": 1,
               "timeContext": {
                 "durationMs": 604800000
@@ -504,7 +504,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "TaniumDiscoverUnmanagedAssets_CL\n|where Ports_s <> \"\" \n|distinct MacAddress_s,Ports_s\n|summarize count() by Ports_s\n\n",
+              "query": "\nTaniumDiscoverUnmanagedAssets_CL\n|where Ports_s != '' \n|distinct MacAddress_s,Ports_s\n|summarize count() by Ports_s\n",
               "size": 0,
               "timeContext": {
                 "durationMs": 2592000000

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -69,7 +69,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "let lastRunTime = toscalar(\n    TaniumComplyVulnerabilities_CL\n    | extend roundedTime = bin(TimeGenerated, 1m) \n    | distinct roundedTime    \n    | order by roundedTime desc     \n    | limit 1);\n\nTaniumComplyVulnerabilities_CL \n| where Scan_Type_s != 'container registries'\n    and TimeGenerated >= lastRunTime\n    and CVSS_v3_Score_d >=9.0\n| extend Host_0_HostName = Computer_Name_s\n| extend Malware_0_Name = CVE_s\n| extend IP_0_Address = IP_Address_s\n| summarize count() by Computer_Name_s \n| limit 10\n| sort by count_",
+              "query": "let lastRunTime = toscalar(\n    TaniumComplyVulnerabilities_CL\n    | extend roundedTime = bin(TimeGenerated, 1m) \n    | distinct roundedTime    \n    | order by roundedTime desc     \n    | limit 1);\n\nTaniumComplyVulnerabilities_CL \n| where Scan_Type_s != 'container registries'\n    and TimeGenerated >= lastRunTime\n    and CVSS_v3_Score_d >=9.0\n| summarize count() by Computer_Name_s \n| limit 10\n| sort by count_",
               "size": 4,
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces",

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -232,7 +232,7 @@
               },
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces",
-              "visualization": "graph",
+              "visualization": "piechart",
               "tileSettings": {
                 "showBorder": false,
                 "titleContent": {

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -298,7 +298,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "TaniumComplyVulnerabilities_CL\n|distinct CVE_s,Computer_Name_s,CVSS_Score_d, Operating_System_Generation_s\n|summarize  CVECount=dcount(CVE_s), cvss_endpoint_score=sum(todecimal(CVSS_Score_d)) by Computer_Name_s, Operating_System_Generation_s\n|project cvss_endpoint_score, CVECount, Computer_Name_s, Operating_System_Generation_s\n|sort by cvss_endpoint_score asc",
+              "query": "TaniumComplyVulnerabilities_CL\n|where Scan_Type_s != 'container registries'\n|distinct CVE_s,Computer_Name_s,CVSS_Score_d, Operating_System_Generation_s\n|summarize  CVECount=dcount(CVE_s), cvss_endpoint_score=sum(todecimal(CVSS_Score_d)) by Computer_Name_s, Operating_System_Generation_s\n|project cvss_endpoint_score, CVECount, Computer_Name_s, Operating_System_Generation_s\n|sort by cvss_endpoint_score asc",
               "size": 0,
               "timeContext": {
                 "durationMs": 604800000

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -227,7 +227,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "TaniumComplyVulnerabilities_CL\n|distinct CVE_s,CVSS_v3_Severity_s\n|summarize count() by CVSS_v3_Severity_s",
+              "query": "let lastRunTime = toscalar(\n    TaniumComplyVulnerabilities_CL\n    | extend roundedTime = bin(TimeGenerated, 1m) \n    | distinct roundedTime    \n    | order by roundedTime desc     \n    | limit 1);\n    \nTaniumComplyVulnerabilities_CL\n|where TimeGenerated >= lastRunTime\n|distinct CVE_s,CVSS_v3_Severity_s\n|summarize count() by CVSS_v3_Severity_s\n",
               "size": 0,
               "timeContext": {
                 "durationMs": 2592000000

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -183,7 +183,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "let getCveYear = (s:string) { substring(s, 4, 4) };\nlet checkCveYearExists = (s:string) { iff(s startswith 'CVE-', getCveYear(s), 'Not Specified') };\nlet extractCveYear = (year:string,cve:string) { iff(year != '', year, checkCveYearExists(cve)) };\n\nlet Vulnerabilities = \nTaniumComplyVulnerabilities_CL\n| extend ParsedCveYear = extractCveYear(CVE_Year_s, CVE_s);\n\nVulnerabilities\n|distinct ParsedCveYear,Computer_Name_s, CVE_s\n|summarize count() by ParsedCveYear\n|sort by ParsedCveYear asc",
+              "query": "let getCveYear = (s:string) { substring(s, 4, 4) };\nlet checkCveYearExists = (s:string) { iff(s startswith 'CVE-', getCveYear(s), 'Not Specified') };\nlet extractCveYear = (year:string,cve:string) { iff(year != '', year, checkCveYearExists(cve)) };\n\nlet lastRunTime = toscalar(\n    TaniumComplyVulnerabilities_CL\n    | extend roundedTime = bin(TimeGenerated, 1m) \n    | distinct roundedTime    \n    | order by roundedTime desc     \n    | limit 1);\n    \nlet Vulnerabilities = \nTaniumComplyVulnerabilities_CL\n|where TimeGenerated >= lastRunTime\n|extend ParsedCveYear = extractCveYear(CVE_Year_s, CVE_s);\n\nVulnerabilities\n|distinct ParsedCveYear,Computer_Name_s, CVE_s\n|summarize count() by ParsedCveYear\n|sort by ParsedCveYear asc",
               "size": 0,
               "timeContext": {
                 "durationMs": 2592000000

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -61,7 +61,7 @@
           {
             "type": 1,
             "content": {
-              "json": "## Top mission critical computers with CVSS hits >= 9.0"
+              "json": "## Top mission critical computers with CVSS v3 hits >= 9.0"
             },
             "name": "visualization title"
           },
@@ -69,7 +69,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "let lastRunTime = toscalar(\n    TaniumComplyVulnerabilities_CL\n    | extend roundedTime = bin(TimeGenerated, 1m) \n    | distinct roundedTime    \n    | order by roundedTime desc     \n    | limit 1);\n\nTaniumComplyVulnerabilities_CL \n| where Scan_Type_s != 'container registries' \n    and TimeGenerated >= lastRunTime\n    and CVSS_Score_d >=9.0\n| extend Host_0_HostName = Computer_Name_s\n| extend Malware_0_Name = CVE_s\n| extend IP_0_Address = IP_Address_s\n| summarize count() by Computer_Name_s \n| sort by count_",
+              "query": "let lastRunTime = toscalar(\n    TaniumComplyVulnerabilities_CL\n    | extend roundedTime = bin(TimeGenerated, 1m) \n    | distinct roundedTime    \n    | order by roundedTime desc     \n    | limit 1);\n\nTaniumComplyVulnerabilities_CL \n| where Scan_Type_s != 'container registries' \n    and TimeGenerated >= lastRunTime\n    and CVSS_v3_Score_d >=9.0\n| extend Host_0_HostName = Computer_Name_s\n| extend Malware_0_Name = CVE_s\n| extend IP_0_Address = IP_Address_s\n| summarize count() by Computer_Name_s \n| sort by count_",
               "size": 4,
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces",

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -69,7 +69,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "TaniumComplyVulnerabilities_CL \n| where CVSS_Score_d >=9.0\n| extend Host_0_HostName = Computer_Name_s\n| extend Malware_0_Name = CVE_s\n| extend IP_0_Address = IP_Address_s\n| summarize count() by Computer_Name_s | limit 4\n| sort by count_\n",
+              "query": "let lastRunTime = toscalar(\n    TaniumComplyVulnerabilities_CL\n    | extend roundedTime = bin(TimeGenerated, 1m)\n    | distinct roundedTime\n    | order by roundedTime desc \n    | limit 1\n);\n\nTaniumComplyVulnerabilities_CL \n| where TimeGenerated >= lastRunTime and Computer_Name_s != "" and CVSS_Score_d >=9.0\n| extend Host_0_HostName = Computer_Name_s\n| extend Malware_0_Name = CVE_s\n| extend IP_0_Address = IP_Address_s\n| summarize count() by Computer_Name_s \n| sort by count_\n",
               "size": 4,
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces",

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -298,7 +298,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "TaniumComplyVulnerabilities_CL\n|where Scan_Type_s != 'container registries' and CVSS_v3_Severity_s != 'Unscored'\n|distinct CVE_s,Computer_Name_s,CVSS_v3_Score_d, Operating_System_Generation_s\n|summarize  CVECount=dcount(CVE_s), cvss_endpoint_score=sum(todecimal(CVSS_v3_Score_d)) by Computer_Name_s, Operating_System_Generation_s\n|sort by cvss_endpoint_score asc",
+              "query": "let lastRunTime = toscalar(\n    TaniumComplyVulnerabilities_CL\n    | extend roundedTime = bin(TimeGenerated, 1m) \n    | distinct roundedTime    \n    | order by roundedTime desc     \n    | limit 1);\n    \nTaniumComplyVulnerabilities_CL\n|where TimeGenerated >= lastRunTime\n    and Scan_Type_s != 'container registries'\n    and CVSS_v3_Severity_s != 'Unscored'\n|distinct CVE_s,Computer_Name_s,CVSS_v3_Score_d, Operating_System_Generation_s\n|summarize  CVECount=dcount(CVE_s), cvss_endpoint_score=sum(todecimal(CVSS_v3_Score_d)) by Computer_Name_s, Operating_System_Generation_s\n|sort by cvss_endpoint_score asc",
               "size": 0,
               "timeContext": {
                 "durationMs": 604800000

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -290,7 +290,7 @@
           {
             "type": 1,
             "content": {
-              "json": "## System Outliers\n#### Based on CVE Count & Aggregate CVSS Score\n"
+              "json": "## System Outliers\n#### Based on CVE (v3) Count & Aggregate CVSS Score\n"
             },
             "name": "visualization title"
           },
@@ -298,7 +298,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "TaniumComplyVulnerabilities_CL\n|where Scan_Type_s != 'container registries'\n|distinct CVE_s,Computer_Name_s,CVSS_Score_d, Operating_System_Generation_s\n|summarize  CVECount=dcount(CVE_s), cvss_endpoint_score=sum(todecimal(CVSS_Score_d)) by Computer_Name_s, Operating_System_Generation_s\n|project cvss_endpoint_score, CVECount, Computer_Name_s, Operating_System_Generation_s\n|sort by cvss_endpoint_score asc",
+              "query": "TaniumComplyVulnerabilities_CL\n|where Scan_Type_s != 'container registries' and CVSS_v3_Severity_s != 'Unscored'\n|distinct CVE_s,Computer_Name_s,CVSS_v3_Score_d, Operating_System_Generation_s\n|summarize  CVECount=dcount(CVE_s), cvss_endpoint_score=sum(todecimal(CVSS_v3_Score_d)) by Computer_Name_s, Operating_System_Generation_s\n|project cvss_endpoint_score, CVECount, Computer_Name_s, Operating_System_Generation_s\n|sort by cvss_endpoint_score asc",
               "size": 0,
               "timeContext": {
                 "durationMs": 604800000

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -69,7 +69,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "TaniumComplyVulnerabilities_CL \n| join TaniumMainAsset_CL on Computer_Name_s| where CVSS_Score_d >=9.0\n| extend Host_0_HostName = Computer_Name_s\n| extend Malware_0_Name = CVE_s\n| extend IP_0_Address = IP_Address_s\n| summarize count() by Computer_Name_s | limit 4\n| sort by count_\n",
+              "query": "TaniumComplyVulnerabilities_CL \n| where CVSS_Score_d >=9.0\n| extend Host_0_HostName = Computer_Name_s\n| extend Malware_0_Name = CVE_s\n| extend IP_0_Address = IP_Address_s\n| summarize count() by Computer_Name_s | limit 4\n| sort by count_\n",
               "size": 4,
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces",

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -177,7 +177,7 @@
             "content": {
               "json": "## Vulnerability distribution by year"
             },
-            "name": "text - 2"
+            "name": "visualization title"
           },
           {
             "type": 3,
@@ -198,7 +198,7 @@
             "content": {
               "json": "## Vulnerability Distribution by OS"
             },
-            "name": "text - 5"
+            "name": "visualization title"
           },
           {
             "type": 3,
@@ -219,13 +219,13 @@
             "content": {
               "json": "## Vulnerability Distribution by Severity"
             },
-            "name": "text - 6"
+            "name": "visualization title"
           },
           {
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "TaniumComplyVulnerabilities_CL\n|distinct CVE_s,Severity_s\n|summarize count() by Severity_s",
+              "query": "TaniumComplyVulnerabilities_CL\n|distinct CVE_s,CVSS_v3_Severity_s\n|summarize count() by CVSS_v3_Severity_s",
               "size": 0,
               "timeContext": {
                 "durationMs": 2592000000
@@ -236,7 +236,7 @@
               "tileSettings": {
                 "showBorder": false,
                 "titleContent": {
-                  "columnMatch": "Severity_s",
+                  "columnMatch": "CVSS_v3_Severity_s",
                   "formatter": 1
                 },
                 "leftContent": {
@@ -257,7 +257,7 @@
               "graphSettings": {
                 "type": 2,
                 "topContent": {
-                  "columnMatch": "Severity_s",
+                  "columnMatch": "CVSS_v3_Severity_s",
                   "formatter": 1
                 },
                 "centerContent": {
@@ -271,7 +271,7 @@
                     }
                   }
                 },
-                "nodeIdField": "Severity_s",
+                "nodeIdField": "CVSS_v3_Severity_s",
                 "graphOrientation": 3,
                 "showOrientationToggles": false,
                 "nodeSize": null,

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -140,7 +140,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "TaniumComplyVulnerabilities_CL \n| where CVSS_v3_Score_d >=9.0 \n| extend Host_0_HostName = Computer_Name_s\n| extend Malware_0_Name = CVE_s\n| extend IP_0_Address = IP_Address_s\n| summarize count() by Operating_System_Generation_s\n| sort by count_",
+              "query": "let lastRunTime = toscalar(\n    TaniumComplyVulnerabilities_CL\n    | extend roundedTime = bin(TimeGenerated, 1m) \n    | distinct roundedTime    \n    | order by roundedTime desc     \n    | limit 1);\n\nTaniumComplyVulnerabilities_CL \n| where TimeGenerated >= lastRunTime\n    and CVSS_v3_Score_d >=9.0 \n| extend Host_0_HostName = Computer_Name_s\n| extend Malware_0_Name = CVE_s\n| extend IP_0_Address = IP_Address_s\n| summarize count() by Operating_System_Generation_s\n| sort by count_",
               "size": 4,
               "timeContext": {
                 "durationMs": 2592000000

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -140,7 +140,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "let lastRunTime = toscalar(\n    TaniumComplyVulnerabilities_CL\n    | extend roundedTime = bin(TimeGenerated, 1m) \n    | distinct roundedTime    \n    | order by roundedTime desc     \n    | limit 1);\n\nTaniumComplyVulnerabilities_CL \n| where TimeGenerated >= lastRunTime\n    and CVSS_v3_Score_d >=9.0 \n| extend Host_0_HostName = Computer_Name_s\n| extend Malware_0_Name = CVE_s\n| extend IP_0_Address = IP_Address_s\n| summarize count() by Operating_System_Generation_s\n| sort by count_",
+              "query": "let lastRunTime = toscalar(\n    TaniumComplyVulnerabilities_CL\n    | extend roundedTime = bin(TimeGenerated, 1m) \n    | distinct roundedTime    \n    | order by roundedTime desc     \n    | limit 1);\n\nTaniumComplyVulnerabilities_CL \n| where TimeGenerated >= lastRunTime\n    and CVSS_v3_Score_d >=9.0 \n| summarize count() by Operating_System_Generation_s\n| sort by count_",
               "size": 4,
               "timeContext": {
                 "durationMs": 2592000000

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -373,7 +373,7 @@
             "content": {
               "json": "## Compliance Benchmark - Pass Rate"
             },
-            "name": "text - 10"
+            "name": "visualization title"
           },
           {
             "type": 3,
@@ -405,7 +405,7 @@
             "content": {
               "json": "## Top 10 Benchmark Failures"
             },
-            "name": "text - 12"
+            "name": "visualization title"
           },
           {
             "type": 3,
@@ -429,7 +429,7 @@
         "value": "Comply"
       },
       "customWidth": "100",
-      "name": "cvss_group",
+      "name": "comply group",
       "styleSettings": {
         "maxWidth": "100"
       }
@@ -541,7 +541,7 @@
       "content": {
         "version": "NotebookGroup/1.0",
         "groupType": "editable",
-        "title": "MIcrosoft Tooling Health ",
+        "title": "Microsoft Tooling Health ",
         "items": [
           {
             "type": 1,
@@ -614,7 +614,7 @@
         "value": "Microsoft Tooling Health"
       },
       "customWidth": "50",
-      "name": "group - 5"
+      "name": "tooling health column 1"
     },
     {
       "type": 12,
@@ -673,7 +673,7 @@
         "value": "Microsoft Tooling Health"
       },
       "customWidth": "50",
-      "name": "sccm_group"
+      "name": "tooling health column 2"
     },
     {
       "type": 12,

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -134,13 +134,13 @@
             "content": {
               "json": "## Top operating systems with CVSS hits >= 9.0"
             },
-            "name": "text - 4"
+            "name": "visualization title"
           },
           {
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "TaniumComplyVulnerabilities_CL \n| join TaniumMainAsset_CL on Computer_Name_s| where CVSS_Score_s startswith \"9\"\n| extend Host_0_HostName = Computer_Name_s\n| extend Malware_0_Name = CVE_s\n| extend IP_0_Address = IP_Address_s\n| summarize count() by Operating_System_Generation_s\n| sort by count_",
+              "query": "TaniumComplyVulnerabilities_CL \n| join TaniumMainAsset_CL on Computer_Name_s| where CVSS_v3_Score_d >=9.0 \n| extend Host_0_HostName = Computer_Name_s\n| extend Malware_0_Name = CVE_s\n| extend IP_0_Address = IP_Address_s\n| summarize count() by Operating_System_Generation_s\n| sort by count_",
               "size": 4,
               "timeContext": {
                 "durationMs": 2592000000


### PR DESCRIPTION
# Overview
Made fixes in several visualizations in our Sentinel Workbook.

- Comply
  - Top 10 mission critical computers with CVSS v3 hits
  - Top operating systems with CVSS hits >= 9.0
  - Vulnerability Distribution by Year
  - Vulnerability Distribution by OS
  - Vulnerability Distribution by Severity
  - System Outliers
  - Compliance Benchmark - Pass Rate
- Discover
  - All Unmanaged Assets

Also fixed some minor typos, capitalization and other non-functional changes.

# Change Summary
- Comply
  - Top 10 mission critical computers with CVSS v3 hits
    - Updated to only use data from the last report time
    - Updated to use CVSS v3 scores _(and added text indicator for version)_
    - Removed custom columns that were not used/referenced
    - Removed filter that only showed the top 4 results
    - No longer includes container registry results
    - Removed join on TaniumMainAsset_CL _(not necessary and was not correctly joined)_
  - Top operating systems with CVSS hits >= 9.0
    - Updated to only use data from the last report time
    - Removed custom columns that were not used/referenced
    - Removed join on TaniumMainAsset_CL _(not necessary and was not correctly joined)_
    - Updated to use CVSS v3 scores  _(and added text indicator for version)_
  - Vulnerability Distribution by Year
    - Updated to only use data from the last report time
    - Enriched records where the CVE year was empty by using the CVE name
    - Updated to set the chart type on the object, NOT in the query itself
  - Vulnerability Distribution by OS
    - Updated to only use data from the last report time
    - No longer includes container registry results
    - Updated to set the chart type on the object, NOT in the query itself
  - Vulnerability Distribution by Severity
    - Updated to only use data from the last report time
    - Updated visualization to be a pie chart instead of graph
    - Updated to use CVSS v3 severity _(and added text indicator for version)_
  - System Outliers
    - Updated to only use data from the last report time
    - Removed custom columns that were not used/referenced
    - Updated to use CVSS v3 scores and filtered out results in which the v3 has not yet scored the CVE yet
    - No longer includes container registry results
    - Updated to set the chart type on the object, NOT in the query itself
    - Removed join on TaniumMainAsset_CL _(not necessary and was not correctly joined)_
  - Compliance Benchmark - Pass Rate
    - Updated visualization to display as a percentage
    - Filtered out records where rule Id is empty
    - Updated query to replace characters that are not compatible with the Azure Query editor, so that the query is compatible with both JSON and the UI
- Discover
  - All Unmanaged Assets
    - Corrected column name for LastTimeDiscoveredAt