### PR TITLE
fix(workbooks, discover) Updated to only pull from most recent data

### DIFF
--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -526,7 +526,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "TaniumDiscoverUnmanagedAssets_CL\n| where HostName_s <> \"\"\n| project Hostname=HostName_s, MacAddres=MacAddress_s, IPAddress, MacOrganization=MacOrganization_s, LastDiscoveredTime=LastDiscoveredAt_t\n| sort by LastDiscoveredTime",
+              "query": "let lastRunTime = toscalar(\nTaniumDiscoverUnmanagedAssets_CL\n| extend roundedTime = bin(TimeGenerated, 1m) \n| distinct roundedTime    \n| order by roundedTime desc     \n| limit 1);\n\nTaniumDiscoverUnmanagedAssets_CL\n| where TimeGenerated >= lastRunTime and HostName_s <> ''\n| project Hostname=HostName_s, MacAddres=MacAddress_s, IPAddress, MacOrganization=MacOrganization_s, LastDiscoveredTime=LastDiscoveredAt_t\n| sort by LastDiscoveredTime",
               "size": 0,
               "timeContext": {
                 "durationMs": 86400000

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -482,7 +482,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "TaniumDiscoverUnmanagedAssets_CL\n|where MacOrganization_s <> \"\" \n|distinct MacAddress_s,MacOrganization_s\n|summarize count() by MacOrganization_s",
+              "query": "let lastRunTime = toscalar(\nTaniumDiscoverUnmanagedAssets_CL\n| extend roundedTime = bin(TimeGenerated, 1m) \n| distinct roundedTime    \n| order by roundedTime desc     \n| limit 1);\n\nTaniumDiscoverUnmanagedAssets_CL\n|where TimeGenerated >= lastRunTime and  MacOrganization_s <> '' \n|distinct MacAddress_s, MacOrganization_s\n|summarize count() by MacOrganization_s",
               "size": 0,
               "timeContext": {
                 "durationMs": 2592000000

--- a/Solutions/Tanium/Workbooks/TaniumWorkbook.json
+++ b/Solutions/Tanium/Workbooks/TaniumWorkbook.json
@@ -460,7 +460,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "TaniumDiscoverUnmanagedAssets_CL\n|where Os_s <> \"\" \n|distinct MacAddress_s,Os_s\n|summarize count() by Os_s\n",
+              "query": "let lastRunTime = toscalar(\n    TaniumDiscoverUnmanagedAssets_CL\n    | extend roundedTime = bin(TimeGenerated, 1m) \n    | distinct roundedTime    \n    | order by roundedTime desc     \n    | limit 1);\n    \n    TaniumDiscoverUnmanagedAssets_CL\n    | where TimeGenerated >= lastRunTime and Os_s <> '' \n    | distinct MacAddress_s, Os_s\n    | summarize count() by Os_s\n    \n    ",
               "size": 0,
               "timeContext": {
                 "durationMs": 2592000000


### PR DESCRIPTION
# Overview
Made fixes in multiple visualizations in our Sentinel Workbook for the Discover tab.

- Discover
  - Unmanaged OS Platform
  - Unmanaged Device Type
  - All Unmanaged Assets

# Change Summary
- Discover
  - Unmanaged OS Platform
    - Updated to only use data from the last report time
  - Unmanaged Device Type
    - Updated to only use data from the last report time
  - All Unmanaged Assets
    - Updated to only use data from the last report time
