### PR TITLE
feat(playbooks) Use Managed Identity with MS Defender Health playbook

### DIFF
--- a/Solutions/Tanium/Playbooks/Tanium-MSDefenderHealth/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-MSDefenderHealth/azuredeploy.json
@@ -70,7 +70,7 @@
     "resources": [
         {
             "type": "Microsoft.Web/connections",
-            "apiVersion": "2018-07-01-preview",
+            "apiVersion": "2016-06-01",
             "name": "[parameters('AzureSentinelConnectionName')]",
             "location": "[resourceGroup().location]",
             "properties": {

--- a/Solutions/Tanium/Playbooks/Tanium-MSDefenderHealth/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-MSDefenderHealth/azuredeploy.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-    "contentVersion": "2.0.0.0",
+    "contentVersion": "2.1.0.0",
     "metadata": {
         "title": "Tanium-MSDefenderHealth",
         "description": "This playbook starts with a Microsoft Sentinel incident, gets the hosts associated with that incident, queries the Tanium API Gateway for the Microsoft Defender Health for those hosts, and then adds a comment to the incident with that information.",
@@ -22,12 +22,19 @@
         "author": {
             "name": "Tanium"
         },
-        "parameterTemplateVersion": "2.0.1"
+        "parameterTemplateVersion": "3.0.0"
     },
     "parameters": {
         "PlaybookName": {
             "defaultValue": "Tanium-MSDefenderHealth",
             "type": "string"
+        },
+        "AzureSentinelConnectionName": {
+            "defaultValue": "Tanium-ComplyFindings-Sentinel-WebConn",
+            "type": "string",
+            "metadata": {
+                "description": "The name to use for the Sentinel Connector in the Logic App . (This will exist as an API Connection in your subscription)"
+            }
         },
         "IntegrationAccountName": {
             "defaultValue": "",
@@ -58,21 +65,21 @@
         }
     },
     "variables": {
-        "AzureSentinelConnectionName": "[concat('azuresentinel-', parameters('PlaybookName'))]",
         "TaniumApiGatewayApi": "[uri(concat('https://',parameters('TaniumServerHostname')),'/plugin/products/gateway/graphql')]"
     },
     "resources": [
         {
             "type": "Microsoft.Web/connections",
             "apiVersion": "2018-07-01-preview",
-            "name": "[variables('AzureSentinelConnectionName')]",
+            "name": "[parameters('AzureSentinelConnectionName')]",
             "location": "[resourceGroup().location]",
             "properties": {
-                "displayName": "[variables('AzureSentinelConnectionName')]",
+                "displayName": "[parameters('AzureSentinelConnectionName')]",
                 "customParameterValues": {},
                 "api": {
                     "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/azuresentinel')]"
-                }
+                },
+                "parameterValueType": "Alternative"
             }
         },
         {
@@ -80,8 +87,11 @@
             "apiVersion": "2019-05-01",
             "name": "[parameters('PlaybookName')]",
             "location": "[resourceGroup().location]",
+            "identity": {
+                "type": "SystemAssigned"
+            },
             "dependsOn": [
-                "[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]"
+                "[resourceId('Microsoft.Web/connections', parameters('AzureSentinelConnectionName'))]"
             ],
             "properties": {
                 "state": "Enabled",
@@ -393,7 +403,7 @@
                             }
                         },
                         "Initialize_Endpoint_Source_to_TDS": {
-                             "runAfter": {
+                            "runAfter": {
                                 "Exit_early_if_incident_has_no_hosts": [
                                     "SUCCEEDED"
                                 ]
@@ -813,9 +823,14 @@
                     "$connections": {
                         "value": {
                             "azuresentinel": {
-                                "connectionName": "[variables('AzureSentinelConnectionName')]",
-                                "connectionId": "[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]",
-                                "id": "[concat('/subscriptions/',subscription().subscriptionId, '/providers/Microsoft.Web/locations/',resourceGroup().location,'/managedApis/azuresentinel')]"
+                                "connectionName": "[parameters('AzureSentinelConnectionName')]",
+                                "connectionId": "[resourceId('Microsoft.Web/connections', parameters('AzureSentinelConnectionName'))]",
+                                "id": "[concat('/subscriptions/',subscription().subscriptionId, '/providers/Microsoft.Web/locations/',resourceGroup().location,'/managedApis/azuresentinel')]",
+                                "connectionProperties": {
+                                    "authentication": {
+                                        "type": "ManagedServiceIdentity"
+                                    }
+                                }
                             }
                         }
                     },

--- a/Solutions/Tanium/Playbooks/Tanium-MSDefenderHealth/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-MSDefenderHealth/azuredeploy.json
@@ -123,7 +123,7 @@
                         }
                     },
                     "actions": {
-                        "Add_comment_to_incident_(V3)_2": {
+                        "Add_Received_Info_to_Incident": {
                             "runAfter": {
                                 "Create_HTML_table": [
                                     "Succeeded"
@@ -170,10 +170,9 @@
                                 "path": "/entities/host"
                             }
                         },
-                        "Exit_early_if_no_hosts_are_found": {
+                        "Exit_early_if_incident_has_no_hosts": {
                             "actions": {
-                                "Add_comment_to_incident_(V3)": {
-                                    "runAfter": {},
+                                "Add_comment__-_no_hosts_found": {
                                     "type": "ApiConnection",
                                     "inputs": {
                                         "body": {
@@ -189,9 +188,9 @@
                                         "path": "/Incidents/Comment"
                                     }
                                 },
-                                "Terminate": {
+                                "Exit_early": {
                                     "runAfter": {
-                                        "Add_comment_to_incident_(V3)": [
+                                        "Add_comment__-_no_hosts_found": [
                                             "Succeeded"
                                         ]
                                     },
@@ -216,7 +215,10 @@
                                     }
                                 ]
                             },
-                            "type": "If"
+                            "type": "If",
+                            "else": {
+                                "actions": {}
+                            }
                         },
                         "Flatten_API_Gateway_endpoints": {
                             "runAfter": {
@@ -240,9 +242,9 @@
                             },
                             "type": "JavaScriptCode"
                         },
-                        "Initialize_API_Gateway_Query": {
+                        "Initialize_API_Query": {
                             "runAfter": {
-                                "Exit_early_if_no_hosts_are_found": [
+                                "Exit_early_if_incident_has_no_hosts": [
                                     "Succeeded"
                                 ]
                             },
@@ -250,7 +252,7 @@
                             "inputs": {
                                 "variables": [
                                     {
-                                        "name": "api gateway query",
+                                        "name": "apiQuery",
                                         "type": "string",
                                         "value": "query ($incidentHosts: EndpointFieldFilter, $endCursor: Cursor, $source: EndpointSource) {\n  endpoints(source: $source, first: 10, after: $endCursor, filter: $incidentHosts) {\n    edges {\n      node {\n        name\n        ipAddress\n        sensorReadings(\n          sensors: [{name: \"Microsoft Defender Installed\"}, {name: \"Microsoft Defender Health Details\"}]\n        ) {\n          columns {\n            sensor {\n              name\n            }\n            name\n            values\n          }\n        }\n      }\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}"
                                     }
@@ -258,26 +260,29 @@
                             },
                             "description": "To check this query against a Tanium Server question use this in the query variables: {\"source\":{\"ts\":{\"stableWaitTime\":10}}}"
                         },
-                        "Initialize_API_Gateway_Query_Variables": {
+                        "Initialize_API_Variables": {
                             "runAfter": {
-                                "Initialize_Tanium_Endpoint_Source_to_TDS": [
+                                "Initialize_Endpoint_Source_to_TDS": [
                                     "Succeeded"
+                                ],
+                                "Set_Endpoint_Filter": [
+                                    "SUCCEEDED"
                                 ]
                             },
                             "type": "InitializeVariable",
                             "inputs": {
                                 "variables": [
                                     {
-                                        "name": "api gateway query variables",
+                                        "name": "queryVariables",
                                         "type": "string",
-                                        "value": "{\n  \"source\": @{variables('Tanium Endpoint Source')},\n  \"incidentHosts\": {\n    \"any\": true,\n    \"filters\": @{variables('endpoint filters')}\n  }\n}"
+                                        "value": "{\n  \"source\": @{variables('endpointSource')},\n  \"incidentHosts\": {\n    \"any\": true,\n    \"filters\": @{variables('endpointFilters')}\n  }\n}"
                                     }
                                 ]
                             }
                         },
-                        "Initialize_API_Gateway_Response": {
+                        "Initialize_API_Response": {
                             "runAfter": {
-                                "Query_API_Gateway": [
+                                "Get_MS_Defender_Status": [
                                     "Succeeded"
                                 ]
                             },
@@ -285,16 +290,16 @@
                             "inputs": {
                                 "variables": [
                                     {
-                                        "name": "API Gateway Response",
+                                        "name": "apiResponse",
                                         "type": "object",
-                                        "value": "@body('Query_API_Gateway')"
+                                        "value": "@body('Get_MS_Defender_Status')"
                                     }
                                 ]
                             }
                         },
-                        "Initialize_API_Gateway_query_cursor": {
+                        "Initialize_response_cursor": {
                             "runAfter": {
-                                "Stop_If_Tanium_Has_No_Hosts_From_Incident": [
+                                "Exit_early_If_Tanium_Has_No_Data_for_Incident": [
                                     "Succeeded"
                                 ]
                             },
@@ -304,22 +309,22 @@
                                     {
                                         "name": "cursor",
                                         "type": "string",
-                                        "value": "@body('Parse_API_Gateway_response')?['data']?['endpoints']?['pageInfo']?['endCursor']"
+                                        "value": "@body('Parse_API_response')?['data']?['endpoints']?['pageInfo']?['endCursor']"
                                     }
                                 ]
                             }
                         },
                         "Initialize_Endpoint_Filter": {
                             "runAfter": {
-                                "Initialize_API_Gateway_Query": [
-                                    "Succeeded"
+                                "Exit_early_if_incident_has_no_hosts": [
+                                    "SUCCEEDED"
                                 ]
                             },
                             "type": "InitializeVariable",
                             "inputs": {
                                 "variables": [
                                     {
-                                        "name": "endpoint filters",
+                                        "name": "endpointFilters",
                                         "type": "array"
                                     }
                                 ]
@@ -327,7 +332,7 @@
                         },
                         "Set_Endpoint_Filter": {
                             "inputs": {
-                                "name": "endpoint filters",
+                                "name": "endpointFilters",
                                 "value": "@body('Build_Endpoint_Filter_from_Hosts')"
                             },
                             "runAfter": {
@@ -337,10 +342,9 @@
                             },
                             "type": "SetVariable"
                         },
-                        "Stop_If_Tanium_Has_No_Hosts_From_Incident": {
+                        "Exit_early_If_Tanium_Has_No_Data_for_Incident": {
                             "actions": {
-                                "Add_comment_to_incident_(V3)_3": {
-                                    "runAfter": {},
+                                "Add_comment__-_no_data_in_Tanium": {
                                     "type": "ApiConnection",
                                     "inputs": {
                                         "body": {
@@ -356,9 +360,9 @@
                                         "path": "/Incidents/Comment"
                                     }
                                 },
-                                "Terminate_no_hosts_in_Tanium": {
+                                "Exit_early__-_no_data_in_Tanium": {
                                     "runAfter": {
-                                        "Add_comment_to_incident_(V3)_3": [
+                                        "Add_comment__-_no_data_in_Tanium": [
                                             "Succeeded"
                                         ]
                                     },
@@ -369,7 +373,7 @@
                                 }
                             },
                             "runAfter": {
-                                "Parse_API_Gateway_response": [
+                                "Parse_API_response": [
                                     "Succeeded"
                                 ]
                             },
@@ -377,25 +381,28 @@
                                 "and": [
                                     {
                                         "equals": [
-                                            "@body('Parse_API_Gateway_response')?['data']?['endpoints']?['pageInfo']?['endCursor']",
+                                            "@body('Parse_API_response')?['data']?['endpoints']?['pageInfo']?['endCursor']",
                                             "@null"
                                         ]
                                     }
                                 ]
                             },
-                            "type": "If"
+                            "type": "If",
+                            "else": {
+                                "actions": {}
+                            }
                         },
-                        "Initialize_Tanium_Endpoint_Source_to_TDS": {
-                            "runAfter": {
-                                "Set_Endpoint_Filter": [
-                                    "Succeeded"
+                        "Initialize_Endpoint_Source_to_TDS": {
+                             "runAfter": {
+                                "Exit_early_if_incident_has_no_hosts": [
+                                    "SUCCEEDED"
                                 ]
                             },
                             "type": "InitializeVariable",
                             "inputs": {
                                 "variables": [
                                     {
-                                        "name": "tanium endpoint source",
+                                        "name": "endpointSource",
                                         "type": "object",
                                         "value": {
                                             "tds": {
@@ -406,10 +413,10 @@
                                 ]
                             }
                         },
-                        "Initialize_endpoints_array": {
+                        "Initialize_list_of_endpoints": {
                             "runAfter": {
-                                "Initialize_API_Gateway_query_cursor": [
-                                    "Succeeded"
+                                "Exit_early_If_Tanium_Has_No_Data_for_Incident": [
+                                    "SUCCEEDED"
                                 ]
                             },
                             "type": "InitializeVariable",
@@ -418,20 +425,19 @@
                                     {
                                         "name": "endpoints",
                                         "type": "array",
-                                        "value": "@body('Parse_API_Gateway_response')?['data']?['endpoints']?['edges']"
+                                        "value": "@body('Parse_API_response')?['data']?['endpoints']?['edges']"
                                     }
                                 ]
                             }
                         },
-                        "Paginate_API_Gateway_query_if_needed": {
+                        "Loop_Paginated_Response_if_has_multiple_pages": {
                             "actions": {
-                                "Until": {
+                                "Until_no_more_pages": {
                                     "actions": {
                                         "For_each_endpoint_in_paginated_API_Gateway_response": {
-                                            "foreach": "@body('Parse_paginated_API_Gateway_response')?['data']?['endpoints']?['edges']",
+                                            "foreach": "@body('Parse_page')?['data']?['endpoints']?['edges']",
                                             "actions": {
                                                 "Append_endpoint_to_endpoints": {
-                                                    "runAfter": {},
                                                     "type": "AppendToArrayVariable",
                                                     "inputs": {
                                                         "name": "endpoints",
@@ -451,17 +457,17 @@
                                                 }
                                             }
                                         },
-                                        "Paginate_API_Gateway": {
+                                        "Get_next_page": {
                                             "runAfter": {
-                                                "Update_API_Gateway_query_variables": [
+                                                "Update_cursor_for_next_page": [
                                                     "Succeeded"
                                                 ]
                                             },
                                             "type": "Http",
                                             "inputs": {
                                                 "body": {
-                                                    "query": "@variables('api gateway query')",
-                                                    "variables": "@json(variables('api gateway query variables'))"
+                                                    "query": "@variables('apiQuery')",
+                                                    "variables": "@json(variables('queryVariables'))"
                                                 },
                                                 "headers": {
                                                     "Content-Type": "application/json",
@@ -478,15 +484,15 @@
                                                 }
                                             }
                                         },
-                                        "Parse_paginated_API_Gateway_response": {
+                                        "Parse_page": {
                                             "runAfter": {
-                                                "Paginate_API_Gateway": [
+                                                "Get_next_page": [
                                                     "Succeeded"
                                                 ]
                                             },
                                             "type": "ParseJson",
                                             "inputs": {
-                                                "content": "@body('Paginate_API_Gateway')",
+                                                "content": "@body('Get_next_page')",
                                                 "schema": {
                                                     "properties": {
                                                         "data": {
@@ -543,27 +549,25 @@
                                         },
                                         "Update_API_Gateway_query_cursor": {
                                             "runAfter": {
-                                                "Parse_paginated_API_Gateway_response": [
+                                                "Parse_page": [
                                                     "Succeeded"
                                                 ]
                                             },
                                             "type": "SetVariable",
                                             "inputs": {
                                                 "name": "cursor",
-                                                "value": "@body('Parse_paginated_API_Gateway_response')?['data']?['endpoints']?['pageInfo']?['endCursor']"
+                                                "value": "@body('Parse_page')?['data']?['endpoints']?['pageInfo']?['endCursor']"
                                             }
                                         },
-                                        "Update_API_Gateway_query_variables": {
-                                            "runAfter": {},
+                                        "Update_cursor_for_next_page": {
                                             "type": "SetVariable",
                                             "inputs": {
-                                                "name": "api gateway query variables",
-                                                "value": "{\n  \"source\": @{variables('tanium endpoint source')},\n  \"endCursor\": \"@{variables('cursor')}\"\n}"
+                                                "name": "queryVariables",
+                                                "value": "{\n  \"source\": @{variables('endpointSource')},\n  \"endCursor\": \"@{variables('cursor')}\"\n}"
                                             }
                                         }
                                     },
-                                    "runAfter": {},
-                                    "expression": "@equals(body('Parse_paginated_API_Gateway_response')?['data']?['endpoints']?['pageInfo']?['hasNextPage'], false)",
+                                    "expression": "@equals(body('Parse_page')?['data']?['endpoints']?['pageInfo']?['hasNextPage'],false)",
                                     "limit": {
                                         "count": 60,
                                         "timeout": "PT1H"
@@ -572,23 +576,29 @@
                                 }
                             },
                             "runAfter": {
-                                "Initialize_endpoints_array": [
+                                "Initialize_list_of_endpoints": [
                                     "Succeeded"
+                                ],
+                                "Initialize_response_cursor": [
+                                    "SUCCEEDED"
                                 ]
                             },
                             "expression": {
                                 "and": [
                                     {
                                         "equals": [
-                                            "@body('Parse_API_Gateway_response')?['data']?['endpoints']?['pageInfo']?['hasNextPage']",
+                                            "@body('Parse_API_response')?['data']?['endpoints']?['pageInfo']?['hasNextPage']",
                                             "@true"
                                         ]
                                     }
                                 ]
                             },
-                            "type": "If"
+                            "type": "If",
+                            "else": {
+                                "actions": {}
+                            }
                         },
-                        "Parse_API_Gateway_response": {
+                        "Parse_API_response": {
                             "runAfter": {
                                 "Switch_to_TS_from_TDS_if_needed": [
                                     "Succeeded"
@@ -596,7 +606,7 @@
                             },
                             "type": "ParseJson",
                             "inputs": {
-                                "content": "@variables('API Gateway Response')",
+                                "content": "@variables('apiResponse')",
                                 "schema": {
                                     "properties": {
                                         "data": {
@@ -668,7 +678,7 @@
                         },
                         "Parse_endpoints_array": {
                             "runAfter": {
-                                "Paginate_API_Gateway_query_if_needed": [
+                                "Loop_Paginated_Response_if_has_multiple_pages": [
                                     "Succeeded"
                                 ]
                             },
@@ -681,17 +691,20 @@
                             },
                             "description": "We need an action's output to use in the JavaScript code since it can't read from a variable"
                         },
-                        "Query_API_Gateway": {
+                        "Get_MS_Defender_Status": {
                             "runAfter": {
-                                "Initialize_API_Gateway_Query_Variables": [
+                                "Initialize_API_Variables": [
                                     "Succeeded"
+                                ],
+                                "Initialize_API_Query": [
+                                    "SUCCEEDED"
                                 ]
                             },
                             "type": "Http",
                             "inputs": {
                                 "body": {
-                                    "query": "@variables('api gateway query')",
-                                    "variables": "@json(variables('api gateway query variables'))"
+                                    "query": "@variables('apiQuery')",
+                                    "variables": "@json(variables('queryVariables'))"
                                 },
                                 "headers": {
                                     "Content-Type": "application/json",
@@ -719,8 +732,8 @@
                                     "type": "Http",
                                     "inputs": {
                                         "body": {
-                                            "query": "@variables('api gateway query')",
-                                            "variables": "@json(variables('api gateway query variables'))"
+                                            "query": "@variables('apiQuery')",
+                                            "variables": "@json(variables('queryVariables'))"
                                         },
                                         "headers": {
                                             "Content-Type": "application/json",
@@ -737,11 +750,10 @@
                                         }
                                     }
                                 },
-                                "Set_Tanium_Endpoint_Source_to_TS": {
-                                    "runAfter": {},
+                                "Change_Endpoint_Source_to_TS": {
                                     "type": "SetVariable",
                                     "inputs": {
-                                        "name": "tanium endpoint source",
+                                        "name": "endpointSource",
                                         "value": {
                                             "ts": {
                                                 "stableWaitTime": 30
@@ -757,25 +769,25 @@
                                     },
                                     "type": "SetVariable",
                                     "inputs": {
-                                        "name": "API Gateway Response",
+                                        "name": "apiResponse",
                                         "value": "@body('Requery_the_API_Gateway')"
                                     }
                                 },
                                 "Update_API_Query_variables_to_get_new_source": {
                                     "runAfter": {
-                                        "Set_Tanium_Endpoint_Source_to_TS": [
+                                        "Change_Endpoint_Source_to_TS": [
                                             "Succeeded"
                                         ]
                                     },
                                     "type": "SetVariable",
                                     "inputs": {
-                                        "name": "api gateway query variables",
-                                        "value": "{\n  \"source\": @{variables('Tanium Endpoint Source')},\n  \"incidentHosts\": {\n    \"any\": true,\n    \"filters\": @{variables('endpoint filters')}\n  }\n}"
+                                        "name": "queryVariables",
+                                        "value": "{\n  \"source\": @{variables('endpointSource')},\n  \"incidentHosts\": {\n    \"any\": true,\n    \"filters\": @{variables('endpointFilters')}\n  }\n}"
                                     }
                                 }
                             },
                             "runAfter": {
-                                "Initialize_API_Gateway_Response": [
+                                "Initialize_API_Response": [
                                     "Succeeded"
                                 ]
                             },
@@ -783,13 +795,16 @@
                                 "and": [
                                     {
                                         "contains": [
-                                            "@string(body('Query_API_Gateway'))",
+                                            "@string(body('Get_MS_Defender_Status'))",
                                             "must refer to an existing sensor"
                                         ]
                                     }
                                 ]
                             },
-                            "type": "If"
+                            "type": "If",
+                            "else": {
+                                "actions": {}
+                            }
                         }
                     },
                     "outputs": {}

--- a/Solutions/Tanium/Playbooks/Tanium-MSDefenderHealth/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-MSDefenderHealth/azuredeploy.json
@@ -30,7 +30,7 @@
             "type": "string"
         },
         "AzureSentinelConnectionName": {
-            "defaultValue": "Tanium-ComplyFindings-Sentinel-WebConn",
+            "defaultValue": "Tanium-MSDefenderHealth-Sentinel-WebConn",
             "type": "string",
             "metadata": {
                 "description": "The name to use for the Sentinel Connector in the Logic App . (This will exist as an API Connection in your subscription)"
@@ -57,10 +57,10 @@
             }
         },
         "TaniumServerHostname": {
-            "defaultValue": "hostname",
+            "defaultValue": "<customerName>-api.cloud.tanium.com",
             "type": "String",
             "metadata": {
-                "description": "The hostname for your Tanium server e.g. tanium.example.com"
+                "description": "The hostname for your Tanium server's API. For cloud customers use <customerName>-api.cloud.tanium.com. For on-onprem use the hostname of your server."
             }
         }
     },

--- a/Solutions/Tanium/Playbooks/Tanium-MSDefenderHealth/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-MSDefenderHealth/azuredeploy.json
@@ -13,7 +13,7 @@
             "1. Ensure the Logic App API connection to Microsoft Sentinel is authenticated."
         ],
         "entities": [ "host" ],
-        "tags": ["Enrichment"],
+        "tags": [ "Enrichment" ],
         "lastUpdateTime": "2023-12-07T00:00:00.000Z",
         "support": {
             "tier": "developer",
@@ -63,17 +63,17 @@
     },
     "resources": [
         {
-          "type": "Microsoft.Web/connections",
-          "apiVersion": "2018-07-01-preview",
-          "name": "[variables('AzureSentinelConnectionName')]",
-          "location": "[resourceGroup().location]",
-          "properties": {
-              "displayName": "[variables('AzureSentinelConnectionName')]",
-              "customParameterValues": {},
-              "api": {
-                  "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/azuresentinel')]"
-              }
-          }
+            "type": "Microsoft.Web/connections",
+            "apiVersion": "2018-07-01-preview",
+            "name": "[variables('AzureSentinelConnectionName')]",
+            "location": "[resourceGroup().location]",
+            "properties": {
+                "displayName": "[variables('AzureSentinelConnectionName')]",
+                "customParameterValues": {},
+                "api": {
+                    "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/azuresentinel')]"
+                }
+            }
         },
         {
             "type": "Microsoft.Logic/workflows",
@@ -81,7 +81,7 @@
             "name": "[parameters('PlaybookName')]",
             "location": "[resourceGroup().location]",
             "dependsOn": [
-              "[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]"
+                "[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]"
             ],
             "properties": {
                 "state": "Enabled",


### PR DESCRIPTION
# Overview

Updated the MS Defender Health playbook.

# Change Summary

## Reorganized

Reorganized and updated names of actions within the playbook to make it far more readable and easier to view/understand when in the GUI editor in Azure Portal.

## Updated Sentinel Connection

The API Connection that was created to allow the playbook to connect to Azure Sentinel (and interact, like leaving comments or using incident triggers) was having to be manually authorized and therefore also impersonating the user who authorized it.

Updated the ARM template to use managed identity for the logic app itself and then use that for the connection, so that when the playbook is created it is already authorized.