### PR TITLE
feat(playbooks) Update Threat Response Alert playbook to use managed identity plus refresh

### DIFF
--- a/Solutions/Tanium/Playbooks/Tanium-ResolveThreatResponseAlert/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-ResolveThreatResponseAlert/azuredeploy.json
@@ -211,7 +211,7 @@
             },
             "Initialize_API_Variables": {
               "runAfter": {
-                "Initialize_API_Mutation": [
+                "Extract_Threat_Response_Alert_GUID": [
                   "Succeeded"
                 ]
               },
@@ -233,6 +233,9 @@
             "Resolve_Threat_Response_Alert": {
               "runAfter": {
                 "Initialize_API_Variables": [
+                  "Succeeded"
+                ],
+                "Initialize_API_Mutation": [
                   "Succeeded"
                 ]
               },
@@ -257,7 +260,7 @@
         "parameters": {
           "$connections": {
             "value": {
-              "azuresentinel": {
+               "azuresentinel": {
                 "connectionName": "[variables('AzureSentinelConnectionName')]",
                 "connectionId": "[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]",
                 "id": "[concat('/subscriptions/',subscription().subscriptionId, '/providers/Microsoft.Web/locations/',resourceGroup().location,'/managedApis/azuresentinel')]"

--- a/Solutions/Tanium/Playbooks/Tanium-ResolveThreatResponseAlert/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-ResolveThreatResponseAlert/azuredeploy.json
@@ -230,12 +230,8 @@
                 "variables": [
                   {
                     "name": "apiVariables",
-                    "type": "object",
-                    "value": {
-                      "threatResponseAlert": {
-                        "guid": "@body('Extract_Threat_Response_Alert_GUID')"
-                      }
-                    }
+                    "type": "string",
+                    "value": "{\n  \"threatResponseAlert\": {\n    \"guid\": \"@{body('Extract_Threat_Response_Alert_GUID')}\"\n  }\n}"
                   }
                 ]
               }

--- a/Solutions/Tanium/Playbooks/Tanium-ResolveThreatResponseAlert/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-ResolveThreatResponseAlert/azuredeploy.json
@@ -127,7 +127,7 @@
             }
           },
           "actions": {
-            "Check_API_Gateway_response": {
+            "Was_Alert_Found": {
               "actions": {
                 "Comment_success": {
                   "runAfter": {},
@@ -148,7 +148,7 @@
                 }
               },
               "runAfter": {
-                "Resolve_Threat_Response_Alert_using_Tanium_API_Gateway": [
+                "Resolve_Threat_Response_Alert": [
                   "Succeeded"
                 ]
               },
@@ -160,7 +160,7 @@
                     "inputs": {
                       "body": {
                         "incidentArmId": "@triggerBody()?['object']?['id']",
-                        "message": "<p><span style=\"font-size: 16px\"><strong>Failed to resolve Tanium Threat Response Alert</strong></span></p><p>Threat Response alert @{body('Extract_Threat_Response_Alert_GUID')['body']} failed to resolve<br>\nError: @{body('Resolve_Threat_Response_Alert_using_Tanium_API_Gateway')?['errors']?[0]['message']}</p>"
+                        "message": "<p><span style=\"font-size: 16px\"><strong>Failed to resolve Tanium Threat Response Alert</strong></span></p><p>Threat Response alert @{body('Extract_Threat_Response_Alert_GUID')['body']} failed to resolve<br>\nError: @{body('Resolve_Threat_Response_Alert')?['errors']?[0]['message']}</p>"
                       },
                       "host": {
                         "connection": {
@@ -177,7 +177,7 @@
                 "and": [
                   {
                     "equals": [
-                      "@body('Resolve_Threat_Response_Alert_using_Tanium_API_Gateway')?['errors']",
+                      "@body('Resolve_Threat_Response_Alert')?['errors']",
                       "@null"
                     ]
                   }
@@ -192,7 +192,7 @@
                 "code": "var sentinel = workflowContext.trigger.outputs.body;\r\n\r\nreturn JSON.parse(sentinel.object.properties.relatedEntities.find(function(e) {\r\n\treturn e.kind === 'Url';\r\n}).properties.url.replace(/\\\\/g, '')).alert_guid;"
               }
             },
-            "Initialize_API_Gateway_mutation": {
+            "Initialize_API_Mutation": {
               "runAfter": {
                 "Extract_Threat_Response_Alert_GUID": [
                   "Succeeded"
@@ -202,16 +202,16 @@
               "inputs": {
                 "variables": [
                   {
-                    "name": "api gateway mutation",
+                    "name": "apiMutation",
                     "type": "string",
                     "value": "mutation($threatResponseAlert: ThreatResponseAlertRef!) {\n  threatResponseAlertResolve(ref: $threatResponseAlert) {\n    error {\n      message\n      retryable\n      timedOut\n    }\n    guid\n    resolved\n  }\n}"
                   }
                 ]
               }
             },
-            "Initialize_API_Gateway_mutation_variables": {
+            "Initialize_API_Variables": {
               "runAfter": {
-                "Initialize_API_Gateway_mutation": [
+                "Initialize_API_Mutation": [
                   "Succeeded"
                 ]
               },
@@ -219,7 +219,7 @@
               "inputs": {
                 "variables": [
                   {
-                    "name": "api gateway mutation variables",
+                    "name": "apiVariables",
                     "type": "object",
                     "value": {
                       "threatResponseAlert": {
@@ -230,17 +230,18 @@
                 ]
               }
             },
-            "Resolve_Threat_Response_Alert_using_Tanium_API_Gateway": {
+            "Resolve_Threat_Response_Alert": {
               "runAfter": {
-                "Initialize_API_Gateway_mutation_variables": [
+                "Initialize_API_Variables": [
                   "Succeeded"
                 ]
               },
               "type": "Http",
+              "description": "Uses the Threat response alert Id from the Sentinel Incident to call the Tanium API Gateway and request that it resolve that alert.",
               "inputs": {
                 "body": {
-                  "query": "@variables('api gateway mutation')",
-                  "variables": "@json(variables('api gateway mutation variables'))"
+                  "query": "@variables('apiMutation')",
+                  "variables": "@json(variables('apiVariables'))"
                 },
                 "headers": {
                   "Content-Type": "application/json",

--- a/Solutions/Tanium/Playbooks/Tanium-ResolveThreatResponseAlert/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-ResolveThreatResponseAlert/azuredeploy.json
@@ -6,7 +6,7 @@
     "description": "Maintaining alert hygiene in multiple consoles can be overwhelming. This playbook helps teams keep Tanium Threat Response up-to-date when using Microsoft Sentinel to centrally manage alerts.\nThis playbook will resolve any Tanium Threat Response alerts associated with a Microsoft Sentinel incident.\n\nSee [Tanium Help](https://help.tanium.com/bundle/ConnectAzureSentinel/page/Integrations/MSFT/ConnectAzureSentinel/Overview.htm) for a guide to setting up the Tanium Connector for Sentinel.",
     "prerequisites": [
       "1. Microsoft Sentinel incidents created from Tanium Threat Response alerts by the analytics rules shipped by the Tanium solution for Microsoft Sentinel",
-      "2. A [Tanium API Token](https://help.tanium.com/bundle/ug_console_cloud/page/platform_user/console_api_tokens.html) granting access to your Tanium environment: the query will be made with the user priviledges of that token.",
+      "2. A [Tanium API Token](https://help.tanium.com/bundle/ug_console_cloud/page/platform_user/console_api_tokens.html) granting access to your Tanium environment: the query will be made with the user privileges of that token.",
       "3. Tanium Threat Response installed and operational in your Tanium environment."
     ],
     "postDeploymentSteps": [
@@ -14,7 +14,7 @@
     ],
     "entities": [ "host" ],
     "tags": [ "Remediation" ],
-    "lastUpdateTime": "2022-09-15T00:00:00.000Z",
+    "lastUpdateTime": "2025-06-23T00:00:00.000Z",
     "support": {
       "tier": "developer",
       "link": "https://www.tanium.com"
@@ -22,12 +22,19 @@
     "author": {
       "name": "Tanium"
     },
-    "parameterTemplateVersion": "2.0.1"
+    "parameterTemplateVersion": "3.0.0"
   },
   "parameters": {
     "PlaybookName": {
       "defaultValue": "Tanium-ResolveThreatResponseAlert",
       "type": "string"
+    },
+    "AzureSentinelConnectionName": {
+      "defaultValue": "Tanium-ResolveThreatResponseAlert-Sentinel-WebConn",
+      "type": "string",
+      "metadata": {
+        "description": "The name to use for the Sentinel Connector in the Logic App . (This will exist as an API Connection in your subscription)"
+      }
     },
     "IntegrationAccountName": {
       "defaultValue": "",
@@ -58,21 +65,21 @@
     }
   },
   "variables": {
-    "AzureSentinelConnectionName": "[concat('azuresentinel-', parameters('PlaybookName'))]",
     "TaniumApiGatewayApi": "[uri(concat('https://',parameters('TaniumServerHostname')),'/plugin/products/gateway/graphql')]"
   },
   "resources": [
     {
       "type": "Microsoft.Web/connections",
       "apiVersion": "2018-07-01-preview",
-      "name": "[variables('AzureSentinelConnectionName')]",
+      "name": "[parameters('AzureSentinelConnectionName')]",
       "location": "[resourceGroup().location]",
       "properties": {
-        "displayName": "[variables('AzureSentinelConnectionName')]",
+        "displayName": "[parameters('AzureSentinelConnectionName')]",
         "customParameterValues": {},
         "api": {
           "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/azuresentinel')]"
-        }
+        },
+        "parameterValueType": "Alternative"
       }
     },
     {
@@ -80,12 +87,15 @@
       "apiVersion": "2019-05-01",
       "name": "[parameters('PlaybookName')]",
       "location": "[resourceGroup().location]",
+      "identity": {
+        "type": "SystemAssigned"
+      },
       "tags": {
         "hidden-SentinelTemplateName": "Tanium-ResolveThreatResponseAlert",
-        "hidden-SentinelTemplateVersion": "1.0"
+        "hidden-SentinelTemplateVersion": "2.0"
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]"
+        "[resourceId('Microsoft.Web/connections', parameters('AzureSentinelConnectionName'))]"
       ],
       "properties": {
         "state": "Enabled",
@@ -260,10 +270,15 @@
         "parameters": {
           "$connections": {
             "value": {
-               "azuresentinel": {
-                "connectionName": "[variables('AzureSentinelConnectionName')]",
-                "connectionId": "[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]",
-                "id": "[concat('/subscriptions/',subscription().subscriptionId, '/providers/Microsoft.Web/locations/',resourceGroup().location,'/managedApis/azuresentinel')]"
+              "azuresentinel": {
+                "connectionName": "[parameters('AzureSentinelConnectionName')]",
+                "connectionId": "[resourceId('Microsoft.Web/connections', parameters('AzureSentinelConnectionName'))]",
+                "id": "[concat('/subscriptions/',subscription().subscriptionId, '/providers/Microsoft.Web/locations/',resourceGroup().location,'/managedApis/azuresentinel')]",
+                "connectionProperties": {
+                  "authentication": {
+                    "type": "ManagedServiceIdentity"
+                  }
+                }
               }
             }
           },


### PR DESCRIPTION
# Overview

Updated the Threat Response Alert playbook.

# Change Summary

## Reorganized

Reorganized and updated names of actions within the playbook to make it far more readable and easier to view/understand when using the GUI editor in Azure Portal.

## Updated Sentinel Connection

The API Connection that was created to allow the playbook to connect to Azure Sentinel _(and interact, like leaving comments or using incident triggers)_ was having to be manually authorized and therefore also impersonating the user who authorized it.

Updated the ARM template to use managed identity for the logic app itself and then use that for the connection, so that when the playbook is created it is already authorized.