### PR TITLE
feat(playbooks: quarantine hosts) Add managed identity and reorganize 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,7 @@
         "endswith",
         "Nmap",
         "scatterchart",
+        "Tanium",
         "todecimal",
         "toint",
         "Unscored",
@@ -37,10 +38,16 @@
         },
         "custom": true,
         "internal-terms": false,
-         "kql-functions": {
+        "kql-functions": {
             "name": "kql-functions",
             "path": "${workspaceRoot}/kql-functions.txt",
             "description": "Functions from KQL that should be ignored.",
+            "addWords": true
+        },
+        "azure-arm-template-words": {
+            "name": "azure-arm-template-words",
+            "path": "${workspaceRoot}/azure-arm-template-words.txt",
+            "description": "ARM Template words that should be ignored.",
             "addWords": true
         }
     }

--- a/Solutions/Tanium/Playbooks/Tanium-QuarantineHosts/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-QuarantineHosts/azuredeploy.json
@@ -21,12 +21,19 @@
         "author": {
             "name": "Tanium"
         },
-        "parameterTemplateVersion": "2.0.1"
+        "parameterTemplateVersion": "3.0.0"
     },
     "parameters": {
         "PlaybookName": {
             "defaultValue": "Tanium-QuarantineHosts",
             "type": "string"
+        },
+        "AzureSentinelConnectionName": {
+            "defaultValue": "Tanium-QuarantineHosts-Sentinel-WebConn",
+            "type": "string",
+            "metadata": {
+                "description": "The name to use for the Sentinel Connector in the Logic App . (This will exist as an API Connection in your subscription)"
+            }
         },
         "IntegrationAccountName": {
             "defaultValue": "",
@@ -57,7 +64,6 @@
         }
     },
     "variables": {
-        "AzureSentinelConnectionName": "[concat('azuresentinel-', parameters('PlaybookName'))]",
         "TaniumActionsApi": "[uri(concat('https://', parameters('TaniumServerHostname')), '/api/v2/actions')]",
         "TaniumAllComputersUrl": "[uri(concat('https://', parameters('TaniumServerHostname')), '/api/v2/groups/by-name/All%20Computers')]",
         "TaniumPackagesByNameUrlFragment": "[uri(concat('https://', parameters('TaniumServerHostname')), '/api/v2/packages/by-name/')]",
@@ -68,14 +74,15 @@
         {
             "type": "Microsoft.Web/connections",
             "apiVersion": "2018-07-01-preview",
-            "name": "[variables('AzureSentinelConnectionName')]",
+            "name": "[parameters('AzureSentinelConnectionName')]",
             "location": "[resourceGroup().location]",
             "properties": {
-                "displayName": "[variables('AzureSentinelConnectionName')]",
+                "displayName": "[parameters('AzureSentinelConnectionName')]",
                 "customParameterValues": {},
                 "api": {
                     "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/azuresentinel')]"
-                }
+                },
+                "parameterValueType": "Alternative"
             }
         },
         {
@@ -83,12 +90,16 @@
             "apiVersion": "2019-05-01",
             "name": "[parameters('PlaybookName')]",
             "location": "[resourceGroup().location]",
+            "identity": {
+                "type": "SystemAssigned"
+            },
+
             "tags": {
                 "hidden-SentinelTemplateName": "Tanium-QuarantineHosts",
                 "hidden-SentinelTemplateVersion": "2.0"
             },
             "dependsOn": [
-                "[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]"
+                "[resourceId('Microsoft.Web/connections', parameters('AzureSentinelConnectionName'))]"
             ],
             "properties": {
                 "state": "Enabled",
@@ -2613,9 +2624,14 @@
                     "$connections": {
                         "value": {
                             "azuresentinel": {
-                                "connectionName": "[variables('AzureSentinelConnectionName')]",
-                                "connectionId": "[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]",
-                                "id": "[concat('/subscriptions/',subscription().subscriptionId, '/providers/Microsoft.Web/locations/',resourceGroup().location,'/managedApis/azuresentinel')]"
+                                "connectionName": "[parameters('AzureSentinelConnectionName')]",
+                                "connectionId": "[resourceId('Microsoft.Web/connections', parameters('AzureSentinelConnectionName'))]",
+                                "id": "[concat('/subscriptions/',subscription().subscriptionId, '/providers/Microsoft.Web/locations/',resourceGroup().location,'/managedApis/azuresentinel')]",
+                                "connectionProperties": {
+                                    "authentication": {
+                                        "type": "ManagedServiceIdentity"
+                                    }
+                                }
                             }
                         }
                     },

--- a/Solutions/Tanium/Playbooks/Tanium-QuarantineHosts/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-QuarantineHosts/azuredeploy.json
@@ -73,7 +73,7 @@
     "resources": [
         {
             "type": "Microsoft.Web/connections",
-            "apiVersion": "2018-07-01-preview",
+            "apiVersion": "2016-06-01",
             "name": "[parameters('AzureSentinelConnectionName')]",
             "location": "[resourceGroup().location]",
             "properties": {

--- a/Solutions/Tanium/Playbooks/Tanium-QuarantineHosts/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-QuarantineHosts/azuredeploy.json
@@ -93,7 +93,6 @@
             "identity": {
                 "type": "SystemAssigned"
             },
-
             "tags": {
                 "hidden-SentinelTemplateName": "Tanium-QuarantineHosts",
                 "hidden-SentinelTemplateVersion": "2.0"
@@ -1360,7 +1359,7 @@
                                     {
                                         "name": "linuxPackageName",
                                         "type": "string",
-                                        "value": "Apply Linux IPTables Quarantine"
+                                        "value": "Threat Response - Quarantine Endpoint [Linux]"
                                     }
                                 ]
                             }
@@ -1376,7 +1375,7 @@
                                     {
                                         "name": "windowsPackageName",
                                         "type": "string",
-                                        "value": "Apply Windows IPsec Quarantine"
+                                        "value": "Threat Response - Quarantine Endpoint [Windows]"
                                     }
                                 ]
                             },
@@ -1394,7 +1393,7 @@
                                     {
                                         "name": "macOsPackageName",
                                         "type": "string",
-                                        "value": "Apply Mac PF Quarantine"
+                                        "value": "Threat Response - Quarantine Endpoint [Mac]"
                                     }
                                 ]
                             },

--- a/Solutions/Tanium/Playbooks/Tanium-QuarantineHosts/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-QuarantineHosts/azuredeploy.json
@@ -56,10 +56,10 @@
             }
         },
         "TaniumServerHostname": {
-            "defaultValue": "hostname",
+            "defaultValue": "<customerName>-api.cloud.tanium.com",
             "type": "String",
             "metadata": {
-                "description": "The hostname for your Tanium server e.g. tanium.example.com"
+                "description": "The hostname for your Tanium server's API. For cloud customers use <customerName>-api.cloud.tanium.com. For on-onprem use the hostname of your server."
             }
         }
     },

--- a/Solutions/Tanium/Playbooks/Tanium-QuarantineHosts/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-QuarantineHosts/azuredeploy.json
@@ -142,100 +142,20 @@
                         }
                     },
                     "actions": {
-                        "Add_comment_to_incident_(V3)_2": {
+                        "Exit_early_if_no_quarantine_actions_were_successfully_issued": {
                             "runAfter": {
-                                "Create_HTML_table_of_issued_actions": [
+                                "Apply_quarantine_action_to_Linux_endpoints": [
+                                    "Succeeded"
+                                ],
+                                "Apply_quarantine_action_to_Windows_endpoints": [
+                                    "Succeeded"
+                                ],
+                                "apply_quarantine_action_to_macOS_endpoints": [
                                     "Succeeded"
                                 ]
                             },
-                            "type": "ApiConnection",
-                            "inputs": {
-                                "body": {
-                                    "incidentArmId": "@triggerBody()?['object']?['id']",
-                                    "message": "<p>ISSUED TANIUM ACTIONS<br>\n@{body('Create_HTML_table_of_issued_actions')}</p>"
-                                },
-                                "host": {
-                                    "connection": {
-                                        "name": "@parameters('$connections')['azuresentinel']['connectionId']"
-                                    }
-                                },
-                                "method": "post",
-                                "path": "/Incidents/Comment"
-                            }
-                        },
-                        "Stop_If_Tanium_Has_No_Hosts_From_Incident": {
-                            "actions": {
-                                "Add_comment_to_incident_(V3)_3": {
-                                    "runAfter": {},
-                                    "type": "ApiConnection",
-                                    "inputs": {
-                                        "body": {
-                                            "incidentArmId": "@triggerBody()?['object']?['id']",
-                                            "message": "<p>No data found in Tanium for hosts.</p>"
-                                        },
-                                        "host": {
-                                            "connection": {
-                                                "name": "@parameters('$connections')['azuresentinel']['connectionId']"
-                                            }
-                                        },
-                                        "method": "post",
-                                        "path": "/Incidents/Comment"
-                                    }
-                                },
-                                "Terminate_no_hosts_in_Tanium": {
-                                    "runAfter": {
-                                        "Add_comment_to_incident_(V3)_3": [
-                                            "Succeeded"
-                                        ]
-                                    },
-                                    "type": "Terminate",
-                                    "inputs": {
-                                        "runStatus": "Succeeded"
-                                    }
-                                }
-                            },
-                            "runAfter": {
-                                "Parse_API_Gateway_response": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "expression": {
-                                "and": [
-                                    {
-                                        "equals": [
-                                            "@body('Parse_API_Gateway_response')?['data']?['endpoints']?['pageInfo']?['endCursor']",
-                                            "@null"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "If"
-                        },
-                        "Add_comment_to_incident_-_hosts_that_will_be_targeted": {
-                            "runAfter": {
-                                "Create_HTML_table_of_matched_endpoints": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "ApiConnection",
-                            "inputs": {
-                                "body": {
-                                    "incidentArmId": "@triggerBody()?['object']?['id']",
-                                    "message": "<p>Preparing to issue quarantine actions targeting these endpoints associated with this incident<br>\n@{body('Create_HTML_table_of_matched_endpoints')}</p>"
-                                },
-                                "host": {
-                                    "connection": {
-                                        "name": "@parameters('$connections')['azuresentinel']['connectionId']"
-                                    }
-                                },
-                                "method": "post",
-                                "path": "/Incidents/Comment"
-                            }
-                        },
-                        "Check_issued_actions": {
                             "actions": {
                                 "Terminate_-_no_actions_were_successfully_issued": {
-                                    "runAfter": {},
                                     "type": "Terminate",
                                     "inputs": {
                                         "runError": {
@@ -245,445 +165,63 @@
                                     }
                                 }
                             },
-                            "runAfter": {
-                                "If_Linux_endpoints": [
-                                    "Succeeded"
-                                ]
-                            },
                             "expression": {
                                 "and": [
                                     {
                                         "less": [
-                                            "@length(variables('issued actions'))",
+                                            "@length(variables('issuedActions'))",
                                             1
                                         ]
                                     }
                                 ]
                             },
-                            "type": "If"
-                        },
-                        "Collect_action_results_for_each_issued_action": {
-                            "foreach": "@variables('issued actions')",
-                            "actions": {
-                                "Get_action_result": {
-                                    "runAfter": {},
-                                    "type": "Http",
-                                    "inputs": {
-                                        "headers": {
-                                            "Content-Type": "application/json",
-                                            "session": "@parameters('TaniumApiToken')"
-                                        },
-                                        "method": "GET",
-                                        "uri": "@{concat(parameters('TaniumActionResultDataUrlFragment'), items('Collect_action_results_for_each_issued_action')?['id'])}"
+                            "type": "If",
+
+                            "else": {
+                                "actions": {
+                                    "Create_HTML_table_of_issued_actions": {
+                                        "type": "Table",
+                                        "inputs": {
+                                            "columns": [
+                                                {
+                                                    "header": "action id",
+                                                    "value": "@item()?['id']"
+                                                },
+                                                {
+                                                    "header": "name",
+                                                    "value": "@item()?['name']"
+                                                },
+                                                {
+                                                    "header": "status",
+                                                    "value": "@item()?['status']"
+                                                }
+                                            ],
+                                            "format": "HTML",
+                                            "from": "@variables('issuedActions')"
+                                        }
                                     },
-                                    "runtimeConfiguration": {
-                                        "secureData": {
-                                            "properties": [
-                                                "inputs"
+                                    "Add_Issued_Actions_to_Incident": {
+                                        "runAfter": {
+                                            "Create_HTML_table_of_issued_actions": [
+                                                "SUCCEEDED"
                                             ]
-                                        }
-                                    }
-                                },
-                                "If_action_result_could_be_determined": {
-                                    "actions": {
-                                        "For_each_action_result_set": {
-                                            "foreach": "@body('Parse_action_result')",
-                                            "actions": {
-                                                "Append_to_action_results": {
-                                                    "runAfter": {},
-                                                    "type": "AppendToArrayVariable",
-                                                    "inputs": {
-                                                        "name": "action results",
-                                                        "value": "@item()"
-                                                    }
+                                        },
+                                        "type": "ApiConnection",
+                                        "inputs": {
+                                            "body": {
+                                                "incidentArmId": "@triggerBody()?['object']?['id']",
+                                                "message": "<p class=\"editor-paragraph\">ISSUED TANIUM ACTIONS<br>@{body('Create_HTML_table_of_issued_actions')}</p>"
+                                            },
+                                            "host": {
+                                                "connection": {
+                                                    "name": "@parameters('$connections')['azuresentinel-1']['connectionId']"
                                                 }
                                             },
-                                            "runAfter": {},
-                                            "type": "Foreach"
-                                        }
-                                    },
-                                    "runAfter": {
-                                        "Parse_action_result": [
-                                            "Succeeded"
-                                        ]
-                                    },
-                                    "else": {
-                                        "actions": {
-                                            "Append_to_unknown_action_results": {
-                                                "runAfter": {
-                                                    "Compose_unknown_action_result": [
-                                                        "Succeeded"
-                                                    ]
-                                                },
-                                                "type": "AppendToArrayVariable",
-                                                "inputs": {
-                                                    "name": "unknown action results",
-                                                    "value": "@outputs('Compose_unknown_action_result')"
-                                                }
-                                            },
-                                            "Compose_unknown_action_result": {
-                                                "runAfter": {},
-                                                "type": "Compose",
-                                                "inputs": {
-                                                    "action id": "@item()?['id']",
-                                                    "status": "Completed with unknown result"
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "expression": {
-                                        "and": [
-                                            {
-                                                "greater": [
-                                                    "@length(outputs('Parse_action_result')['body'])",
-                                                    0
-                                                ]
-                                            }
-                                        ]
-                                    },
-                                    "type": "If"
-                                },
-                                "Parse_action_result": {
-                                    "runAfter": {
-                                        "Parse_current_issued_action": [
-                                            "Succeeded"
-                                        ]
-                                    },
-                                    "type": "JavaScriptCode",
-                                    "inputs": {
-                                        "code": "var action_results = workflowContext.actions.Get_action_result.outputs.body.data;\r\nvar action_id = workflowContext.actions.Parse_current_issued_action.outputs.body.id;\r\nvar columns = action_results.result_sets[0].columns.map(c => c.name);\r\nvar robjects = [];\r\n\r\naction_results.result_sets.forEach(function(rs) {\r\n\trs.rows.forEach(function(row) {\r\n\t\tvar robject = {'action id': action_id};\r\n\t\tcolumns.forEach(function(c, i) {\r\n\t\t\trobject[c] = row.data[i][0].text;\r\n\t\t});\r\n\t\trobjects.push(robject);\r\n\t});\r\n});\r\n\r\nreturn robjects;"
-                                    }
-                                },
-                                "Parse_current_issued_action": {
-                                    "runAfter": {
-                                        "Get_action_result": [
-                                            "Succeeded"
-                                        ]
-                                    },
-                                    "type": "ParseJson",
-                                    "inputs": {
-                                        "content": "@items('Collect_action_results_for_each_issued_action')",
-                                        "schema": {
-                                            "properties": {
-                                                "action_group": {
-                                                    "properties": {
-                                                        "id": {
-                                                            "type": "integer"
-                                                        },
-                                                        "name": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "type": "object"
-                                                },
-                                                "approver": {
-                                                    "properties": {
-                                                        "id": {
-                                                            "type": "integer"
-                                                        },
-                                                        "name": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "type": "object"
-                                                },
-                                                "comment": {
-                                                    "type": "string"
-                                                },
-                                                "creation_time": {
-                                                    "type": "string"
-                                                },
-                                                "distribute_seconds": {
-                                                    "type": "integer"
-                                                },
-                                                "expiration_time": {
-                                                    "type": "string"
-                                                },
-                                                "expire_seconds": {
-                                                    "type": "integer"
-                                                },
-                                                "history_saved_question": {
-                                                    "properties": {
-                                                        "id": {
-                                                            "type": "integer"
-                                                        }
-                                                    },
-                                                    "type": "object"
-                                                },
-                                                "id": {
-                                                    "type": "integer"
-                                                },
-                                                "name": {
-                                                    "type": "string"
-                                                },
-                                                "package_spec": {
-                                                    "properties": {
-                                                        "available_time": {
-                                                            "type": "string"
-                                                        },
-                                                        "command": {
-                                                            "type": "string"
-                                                        },
-                                                        "command_timeout": {
-                                                            "type": "integer"
-                                                        },
-                                                        "content_set": {
-                                                            "properties": {
-                                                                "id": {
-                                                                    "type": "integer"
-                                                                },
-                                                                "name": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "type": "object"
-                                                        },
-                                                        "creation_time": {
-                                                            "type": "string"
-                                                        },
-                                                        "deleted_flag": {
-                                                            "type": "boolean"
-                                                        },
-                                                        "display_name": {
-                                                            "type": "string"
-                                                        },
-                                                        "expire_seconds": {
-                                                            "type": "integer"
-                                                        },
-                                                        "hidden_flag": {
-                                                            "type": "boolean"
-                                                        },
-                                                        "id": {
-                                                            "type": "integer"
-                                                        },
-                                                        "last_modified_by": {
-                                                            "type": "string"
-                                                        },
-                                                        "last_update": {
-                                                            "type": "string"
-                                                        },
-                                                        "mod_user": {
-                                                            "properties": {
-                                                                "display_name": {
-                                                                    "type": "string"
-                                                                },
-                                                                "domain": {
-                                                                    "type": "string"
-                                                                },
-                                                                "id": {
-                                                                    "type": "integer"
-                                                                },
-                                                                "name": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "type": "object"
-                                                        },
-                                                        "modification_time": {
-                                                            "type": "string"
-                                                        },
-                                                        "name": {
-                                                            "type": "string"
-                                                        },
-                                                        "parameter_definition": {
-                                                            "type": "string"
-                                                        },
-                                                        "process_group_flag": {
-                                                            "type": "boolean"
-                                                        },
-                                                        "skip_lock_flag": {
-                                                            "type": "boolean"
-                                                        },
-                                                        "source_hash": {
-                                                            "type": "string"
-                                                        },
-                                                        "verify_expire_seconds": {
-                                                            "type": "integer"
-                                                        },
-                                                        "verify_group": {
-                                                            "properties": {
-                                                                "id": {
-                                                                    "type": "integer"
-                                                                }
-                                                            },
-                                                            "type": "object"
-                                                        },
-                                                        "verify_group_id": {
-                                                            "type": "integer"
-                                                        }
-                                                    },
-                                                    "type": "object"
-                                                },
-                                                "saved_action": {
-                                                    "properties": {
-                                                        "id": {
-                                                            "type": "integer"
-                                                        }
-                                                    },
-                                                    "type": "object"
-                                                },
-                                                "skip_lock_flag": {
-                                                    "type": "boolean"
-                                                },
-                                                "start_time": {
-                                                    "type": "string"
-                                                },
-                                                "status": {
-                                                    "type": "string"
-                                                },
-                                                "stopped_flag": {
-                                                    "type": "boolean"
-                                                },
-                                                "target_group": {
-                                                    "properties": {
-                                                        "id": {
-                                                            "type": "integer"
-                                                        },
-                                                        "name": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "type": "object"
-                                                },
-                                                "user": {
-                                                    "properties": {
-                                                        "creation_time": {
-                                                            "type": "string"
-                                                        },
-                                                        "deleted_flag": {
-                                                            "type": "boolean"
-                                                        },
-                                                        "display_name": {
-                                                            "type": "string"
-                                                        },
-                                                        "domain": {
-                                                            "type": "string"
-                                                        },
-                                                        "effective_group_id": {
-                                                            "type": "integer"
-                                                        },
-                                                        "external_flag": {
-                                                            "type": "integer"
-                                                        },
-                                                        "group_id": {
-                                                            "type": "integer"
-                                                        },
-                                                        "id": {
-                                                            "type": "integer"
-                                                        },
-                                                        "last_login": {
-                                                            "type": "string"
-                                                        },
-                                                        "locked_out": {
-                                                            "type": "integer"
-                                                        },
-                                                        "mod_user": {
-                                                            "properties": {
-                                                                "display_name": {
-                                                                    "type": "string"
-                                                                },
-                                                                "domain": {
-                                                                    "type": "string"
-                                                                },
-                                                                "id": {
-                                                                    "type": "integer"
-                                                                },
-                                                                "name": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "type": "object"
-                                                        },
-                                                        "modification_time": {
-                                                            "type": "string"
-                                                        },
-                                                        "name": {
-                                                            "type": "string"
-                                                        },
-                                                        "previous_login": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "type": "object"
-                                                }
-                                            },
-                                            "type": "object"
+                                            "method": "post",
+                                            "path": "/Incidents/Comment"
                                         }
                                     }
                                 }
-                            },
-                            "runAfter": {
-                                "Initialize_action_results": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "Foreach",
-                            "runtimeConfiguration": {
-                                "concurrency": {
-                                    "repetitions": 1
-                                }
-                            }
-                        },
-                        "Create_HTML_table_of_action_results": {
-                            "runAfter": {
-                                "Collect_action_results_for_each_issued_action": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "Table",
-                            "inputs": {
-                                "format": "HTML",
-                                "from": "@variables('action results')"
-                            }
-                        },
-                        "Create_HTML_table_of_issued_actions": {
-                            "runAfter": {
-                                "Check_issued_actions": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "Table",
-                            "inputs": {
-                                "columns": [
-                                    {
-                                        "header": "action id",
-                                        "value": "@item()?['id']"
-                                    },
-                                    {
-                                        "header": "name",
-                                        "value": "@item()?['name']"
-                                    },
-                                    {
-                                        "header": "status",
-                                        "value": "@item()?['status']"
-                                    }
-                                ],
-                                "format": "HTML",
-                                "from": "@variables('issued actions')"
-                            }
-                        },
-                        "Create_HTML_table_of_matched_endpoints": {
-                            "runAfter": {
-                                "Flatten_API_Gateway_endpoints": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "Table",
-                            "inputs": {
-                                "format": "HTML",
-                                "from": "@body('Flatten_API_Gateway_endpoints')"
-                            }
-                        },
-                        "Create_HTML_table_of_unknown_action_results": {
-                            "runAfter": {
-                                "Create_HTML_table_of_action_results": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "Table",
-                            "inputs": {
-                                "format": "HTML",
-                                "from": "@variables('unknown action results')"
                             }
                         },
                         "Get_Hosts_From_Incident": {
@@ -700,10 +238,9 @@
                                 "path": "/entities/host"
                             }
                         },
-                        "Exit_early_if_no_hosts_are_found": {
+                        "Exit_early_if_incident_has_no_hosts": {
                             "actions": {
-                                "Add_comment_to_incident_(V3)": {
-                                    "runAfter": {},
+                                "Add_comment__-_no_hosts_found": {
                                     "type": "ApiConnection",
                                     "inputs": {
                                         "body": {
@@ -719,9 +256,9 @@
                                         "path": "/Incidents/Comment"
                                     }
                                 },
-                                "Terminate": {
+                                "Exit_early": {
                                     "runAfter": {
-                                        "Add_comment_to_incident_(V3)": [
+                                        "Add_comment__-_no_hosts_found": [
                                             "Succeeded"
                                         ]
                                     },
@@ -746,140 +283,10 @@
                                     }
                                 ]
                             },
-                            "type": "If"
-                        },
-                        "Flatten_API_Gateway_endpoints": {
-                            "runAfter": {
-                                "Parse_endpoints_array": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "JavaScriptCode",
-                            "inputs": {
-                                "code": "var e = workflowContext.actions.Parse_endpoints_array.outputs.body;\r\n\r\nfunction sensorReadings(r) {\r\n\treturn r.columns.map(c => {\r\n\t\tif (c.sensor && c.sensor.name) {\r\n\t\t\treturn { name: [c.sensor.name, c.name].join(' - '), value: c.values.join(' ') };\r\n\t\t} else {\r\n\t\t\treturn { name: c.name, value: c.values.join(' ') };\r\n\t\t}\r\n\t});\r\n}\r\n\r\nfunction flatten(obj, pk = '') {\r\n\tif (pk !== '') pk += ' ';\r\n\tvar flat = {};\r\n\tObject.keys(obj).forEach((key) => {\r\n\t\tif (key === 'sensorReadings') {\r\n\t\t\tsensorReadings(obj[key]).forEach((r) => {\r\n\t\t\t\tflat[r.name] = r.value;\r\n\t\t\t});\r\n\t\t} else {\r\n\t\t\tif (typeof obj[key] === 'object' && obj[key] !== null) {\r\n\t\t\t\tObject.assign(flat, flatten(obj[key], pk + key));\r\n\t\t\t} else {\r\n\t\t\t\tflat[pk + key] = obj[key];\r\n\t\t\t}\r\n\t\t}\r\n\t});\r\n\treturn flat;\r\n}\r\n\r\nreturn e.map(function(e) { return flatten(e.node); });"
+                            "type": "If",
+                            "else": {
+                                "actions": {}
                             }
-                        },
-                        "For_each_endpoint": {
-                            "foreach": "@variables('endpoints')",
-                            "actions": {
-                                "Compose_endpoint_filter_for_packages": {
-                                    "runAfter": {
-                                        "Parse_endpoint_JSON_data": [
-                                            "Succeeded"
-                                        ]
-                                    },
-                                    "type": "Compose",
-                                    "inputs": {
-                                        "and_flag": true,
-                                        "filters": [
-                                            {
-                                                "operator": "Equal",
-                                                "sensor": {
-                                                    "name": "Computer Name"
-                                                },
-                                                "value": "@body('Parse_endpoint_JSON_data')?['node']?['name']"
-                                            },
-                                            {
-                                                "operator": "RegexMatch",
-                                                "sensor": {
-                                                    "name": "IP Address"
-                                                },
-                                                "value": "@body('Parse_endpoint_JSON_data')?['node']?['ipAddress']"
-                                            }
-                                        ]
-                                    }
-                                },
-                                "Parse_endpoint_JSON_data": {
-                                    "runAfter": {},
-                                    "type": "ParseJson",
-                                    "inputs": {
-                                        "content": "@items('For_each_endpoint')",
-                                        "schema": {
-                                            "properties": {
-                                                "node": {
-                                                    "properties": {
-                                                        "ipAddress": {
-                                                            "type": "string"
-                                                        },
-                                                        "name": {
-                                                            "type": "string"
-                                                        },
-                                                        "os": {
-                                                            "properties": {
-                                                                "platform": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "type": "object"
-                                                        }
-                                                    },
-                                                    "type": "object"
-                                                }
-                                            },
-                                            "type": "object"
-                                        }
-                                    }
-                                },
-                                "Switch": {
-                                    "runAfter": {
-                                        "Compose_endpoint_filter_for_packages": [
-                                            "Succeeded"
-                                        ]
-                                    },
-                                    "cases": {
-                                        "Linux": {
-                                            "case": "Linux",
-                                            "actions": {
-                                                "Append_to_Linux_endpoint_filters": {
-                                                    "runAfter": {},
-                                                    "type": "AppendToArrayVariable",
-                                                    "inputs": {
-                                                        "name": "linux endpoint filters",
-                                                        "value": "@outputs('Compose_endpoint_filter_for_packages')"
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "Mac": {
-                                            "case": "Mac",
-                                            "actions": {
-                                                "Append_to_macOS_endpoint_filters": {
-                                                    "runAfter": {},
-                                                    "type": "AppendToArrayVariable",
-                                                    "inputs": {
-                                                        "name": "macos endpoint filters",
-                                                        "value": "@outputs('Compose_endpoint_filter_for_packages')"
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "Windows": {
-                                            "case": "Windows",
-                                            "actions": {
-                                                "Append_to_Windows_endpoint_filters": {
-                                                    "runAfter": {},
-                                                    "type": "AppendToArrayVariable",
-                                                    "inputs": {
-                                                        "name": "windows endpoint filters",
-                                                        "value": "@outputs('Compose_endpoint_filter_for_packages')"
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "default": {
-                                        "actions": {}
-                                    },
-                                    "expression": "@body('Parse_endpoint_JSON_data')?['node']?['os']?['platform']",
-                                    "type": "Switch"
-                                }
-                            },
-                            "runAfter": {
-                                "Initialize_all_computers_id": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "Foreach"
                         },
                         "Build_Endpoint_Filter_from_Hosts": {
                             "inputs": {
@@ -894,7 +301,7 @@
                         },
                         "Set_Endpoint_Filter": {
                             "inputs": {
-                                "name": "endpoint filters",
+                                "name": "endpointFilters",
                                 "value": "@body('Build_Endpoint_Filter_from_Hosts')"
                             },
                             "runAfter": {
@@ -906,7 +313,25 @@
                         },
                         "Get_the_\"All_Computers\"_group": {
                             "runAfter": {
-                                "Initialize_unknown_action_results": [
+                                "Initialize_the_filter_for_Windows_endpoint(s)": [
+                                    "Succeeded"
+                                ],
+                                "Initialize_the_filter_for_Linux_endpoint(s)": [
+                                    "Succeeded"
+                                ],
+                                "Initialize_the_filter_for_macOS_endpoint(s)": [
+                                    "Succeeded"
+                                ],
+                                "Initialize_list_of_issued_actions": [
+                                    "Succeeded"
+                                ],
+                                "Initialize_list_of_unknown_action_results": [
+                                    "Succeeded"
+                                ],
+                                "Initialize_quarantine_package_parameters": [
+                                    "Succeeded"
+                                ],
+                                "Initialize_all_computers_group's_id": [
                                     "Succeeded"
                                 ]
                             },
@@ -927,21 +352,20 @@
                                 }
                             }
                         },
-                        "If_Linux_endpoints": {
+                        "Apply_quarantine_action_to_Linux_endpoints": {
                             "actions": {
                                 "Check_Linux_issued_action_result": {
                                     "actions": {
                                         "Append_Linux_issued_action_result_to_issued_actions": {
-                                            "runAfter": {},
                                             "type": "AppendToArrayVariable",
                                             "inputs": {
-                                                "name": "issued actions",
-                                                "value": "@body('Issue_Linux_action')?['data']"
+                                                "name": "issuedActions",
+                                                "value": "@body('Issue_Linux_Quarantine_action')?['data']"
                                             }
                                         }
                                     },
                                     "runAfter": {
-                                        "Issue_Linux_action": [
+                                        "Issue_Linux_Quarantine_action": [
                                             "Succeeded"
                                         ]
                                     },
@@ -949,13 +373,16 @@
                                         "and": [
                                             {
                                                 "equals": [
-                                                    "@outputs('Issue_Linux_action')['statusCode']",
+                                                    "@outputs('Issue_Linux_Quarantine_action')['statusCode']",
                                                     200
                                                 ]
                                             }
                                         ]
                                     },
-                                    "type": "If"
+                                    "type": "If",
+                                    "else": {
+                                        "actions": {}
+                                    }
                                 },
                                 "Compose_Linux_action": {
                                     "runAfter": {
@@ -966,11 +393,11 @@
                                     "type": "Compose",
                                     "inputs": {
                                         "action_group": {
-                                            "id": "@variables('all computers id')"
+                                            "id": "@variables('allComputersGroupId')"
                                         },
                                         "distribute_seconds": 0,
                                         "expire_seconds": "@body('Parse_Linux_package_json')?['data']?['expire_seconds']",
-                                        "name": "Apply from Microsoft Sentinel: @{variables('linux package name')}",
+                                        "name": "Apply from Microsoft Sentinel: @{variables('linuxPackageName')}",
                                         "package_spec": "@outputs('Compose_Linux_action_package_declaration')",
                                         "target_group": "@outputs('Compose_Linux_target_group')"
                                     }
@@ -984,7 +411,7 @@
                                     "type": "Compose",
                                     "inputs": {
                                         "expire_seconds": "@body('Parse_Linux_package_json')?['data']?['expire_seconds']",
-                                        "parameters": "@variables('package parameters')",
+                                        "parameters": "@variables('packageParameters')",
                                         "source_id": "@body('Parse_Linux_package_json')?['data']?['id']"
                                     }
                                 },
@@ -997,11 +424,10 @@
                                     "type": "Compose",
                                     "inputs": {
                                         "and_flag": false,
-                                        "sub_groups": "@variables('linux endpoint filters')"
+                                        "sub_groups": "@variables('linuxEndpointFilters')"
                                     }
                                 },
-                                "Get_Linux_package": {
-                                    "runAfter": {},
+                                "Get_Linux_Quarantine_package": {
                                     "type": "Http",
                                     "inputs": {
                                         "headers": {
@@ -1009,7 +435,7 @@
                                             "session": "@parameters('TaniumApiToken')"
                                         },
                                         "method": "GET",
-                                        "uri": "@{concat(parameters('TaniumPackagesByNameUrlFragment'), join(split(variables('linux package name'), ' '), '%20'))}"
+                                        "uri": "@{concat(parameters('TaniumPackagesByNameUrlFragment'), join(split(variables('linuxPackageName'), ' '), '%20'))}"
                                     },
                                     "runtimeConfiguration": {
                                         "secureData": {
@@ -1019,7 +445,7 @@
                                         }
                                     }
                                 },
-                                "Issue_Linux_action": {
+                                "Issue_Linux_Quarantine_action": {
                                     "runAfter": {
                                         "Compose_Linux_action": [
                                             "Succeeded"
@@ -1045,13 +471,13 @@
                                 },
                                 "Parse_Linux_package_json": {
                                     "runAfter": {
-                                        "Get_Linux_package": [
+                                        "Get_Linux_Quarantine_package": [
                                             "Succeeded"
                                         ]
                                     },
                                     "type": "ParseJson",
                                     "inputs": {
-                                        "content": "@body('Get_Linux_package')",
+                                        "content": "@body('Get_Linux_Quarantine_package')",
                                         "schema": {
                                             "properties": {
                                                 "data": {
@@ -1162,7 +588,7 @@
                                 }
                             },
                             "runAfter": {
-                                "If_macOS_endpoints": [
+                                "Generate_the_endpoints_filters_for_each_OS_package": [
                                     "Succeeded"
                                 ]
                             },
@@ -1170,29 +596,31 @@
                                 "and": [
                                     {
                                         "greater": [
-                                            "@length(variables('linux endpoint filters'))",
+                                            "@length(variables('linuxEndpointFilters'))",
                                             0
                                         ]
                                     }
                                 ]
                             },
-                            "type": "If"
+                            "type": "If",
+                            "else": {
+                                "actions": {}
+                            }
                         },
-                        "If_Windows_endpoints": {
+                        "Apply_quarantine_action_to_Windows_endpoints": {
                             "actions": {
                                 "Check_Windows_issued_action_result": {
                                     "actions": {
                                         "Append_Windows_issued_action_result_to_issued_actions": {
-                                            "runAfter": {},
                                             "type": "AppendToArrayVariable",
                                             "inputs": {
-                                                "name": "issued actions",
-                                                "value": "@body('Issue_Windows_action')?['data']"
+                                                "name": "issuedActions",
+                                                "value": "@body('Issue_Windows_Quarantine_action')?['data']"
                                             }
                                         }
                                     },
                                     "runAfter": {
-                                        "Issue_Windows_action": [
+                                        "Issue_Windows_Quarantine_action": [
                                             "Succeeded"
                                         ]
                                     },
@@ -1200,13 +628,16 @@
                                         "and": [
                                             {
                                                 "equals": [
-                                                    "@outputs('Issue_Windows_action')['statusCode']",
+                                                    "@outputs('Issue_Windows_Quarantine_action')['statusCode']",
                                                     200
                                                 ]
                                             }
                                         ]
                                     },
-                                    "type": "If"
+                                    "type": "If",
+                                    "else": {
+                                        "actions": {}
+                                    }
                                 },
                                 "Compose_Windows_action_package_declaration": {
                                     "runAfter": {
@@ -1217,7 +648,7 @@
                                     "type": "Compose",
                                     "inputs": {
                                         "expire_seconds": "@body('Parse_Windows_package_json')?['data']?['expire_seconds']",
-                                        "parameters": "@variables('package parameters')",
+                                        "parameters": "@variables('packageParameters')",
                                         "source_id": "@body('Parse_Windows_package_json')?['data']?['id']"
                                     }
                                 },
@@ -1230,7 +661,7 @@
                                     "type": "Compose",
                                     "inputs": {
                                         "and_flag": false,
-                                        "sub_groups": "@variables('windows endpoint filters')"
+                                        "sub_groups": "@variables('windowsEndpointFilters')"
                                     }
                                 },
                                 "Compose_windows_action": {
@@ -1242,17 +673,16 @@
                                     "type": "Compose",
                                     "inputs": {
                                         "action_group": {
-                                            "id": "@variables('all computers id')"
+                                            "id": "@variables('allComputersGroupId')"
                                         },
                                         "distribute_seconds": 0,
                                         "expire_seconds": "@body('Parse_Windows_package_json')?['data']?['expire_seconds']",
-                                        "name": "Apply from Microsoft Sentinel: @{variables('windows package name')}",
+                                        "name": "Apply from Microsoft Sentinel: @{variables('windowsPackageName')}",
                                         "package_spec": "@outputs('Compose_Windows_action_package_declaration')",
                                         "target_group": "@outputs('Compose_Windows_target_group')"
                                     }
                                 },
-                                "Get_Windows_package": {
-                                    "runAfter": {},
+                                "Get_Windows_Quarantine_package": {
                                     "type": "Http",
                                     "inputs": {
                                         "headers": {
@@ -1260,7 +690,7 @@
                                             "session": "@parameters('TaniumApiToken')"
                                         },
                                         "method": "GET",
-                                        "uri": "@{concat(parameters('TaniumPackagesByNameUrlFragment'), join(split(variables('windows package name'), ' '), '%20'))}"
+                                        "uri": "@{concat(parameters('TaniumPackagesByNameUrlFragment'), join(split(variables('windowsPackageName'), ' '), '%20'))}"
                                     },
                                     "runtimeConfiguration": {
                                         "secureData": {
@@ -1270,7 +700,7 @@
                                         }
                                     }
                                 },
-                                "Issue_Windows_action": {
+                                "Issue_Windows_Quarantine_action": {
                                     "runAfter": {
                                         "Compose_windows_action": [
                                             "Succeeded"
@@ -1296,13 +726,13 @@
                                 },
                                 "Parse_Windows_package_json": {
                                     "runAfter": {
-                                        "Get_Windows_package": [
+                                        "Get_Windows_Quarantine_package": [
                                             "Succeeded"
                                         ]
                                     },
                                     "type": "ParseJson",
                                     "inputs": {
-                                        "content": "@body('Get_Windows_package')",
+                                        "content": "@body('Get_Windows_Quarantine_package')",
                                         "schema": {
                                             "properties": {
                                                 "data": {
@@ -1413,7 +843,7 @@
                                 }
                             },
                             "runAfter": {
-                                "For_each_endpoint": [
+                                "Generate_the_endpoints_filters_for_each_OS_package": [
                                     "Succeeded"
                                 ]
                             },
@@ -1421,141 +851,31 @@
                                 "and": [
                                     {
                                         "greater": [
-                                            "@length(variables('windows endpoint filters'))",
+                                            "@length(variables('windowsEndpointFilters'))",
                                             0
                                         ]
                                     }
                                 ]
                             },
-                            "type": "If"
-                        },
-                        "If_action_results": {
-                            "actions": {
-                                "Add_comment_to_incident_(V3)_-_action_results": {
-                                    "runAfter": {},
-                                    "type": "ApiConnection",
-                                    "inputs": {
-                                        "body": {
-                                            "incidentArmId": "@triggerBody()?['object']?['id']",
-                                            "message": "<p>QUARANTINE ACTION RESULTS<br>\n@{body('Create_HTML_table_of_action_results')}</p>"
-                                        },
-                                        "host": {
-                                            "connection": {
-                                                "name": "@parameters('$connections')['azuresentinel']['connectionId']"
-                                            }
-                                        },
-                                        "method": "post",
-                                        "path": "/Incidents/Comment"
-                                    }
-                                }
-                            },
-                            "runAfter": {
-                                "If_action_results_and_unknown_action_results": [
-                                    "Succeeded"
-                                ]
-                            },
+                            "type": "If",
                             "else": {
-                                "actions": {
-                                    "Add_comment_to_incident_(V3)_-_unknown_action_results": {
-                                        "runAfter": {},
-                                        "type": "ApiConnection",
-                                        "inputs": {
-                                            "body": {
-                                                "incidentArmId": "@triggerBody()?['object']?['id']",
-                                                "message": "<p>QUARANTINE ACTION RESULTS<br>\n@{body('Create_HTML_table_of_unknown_action_results')}</p>"
-                                            },
-                                            "host": {
-                                                "connection": {
-                                                    "name": "@parameters('$connections')['azuresentinel']['connectionId']"
-                                                }
-                                            },
-                                            "method": "post",
-                                            "path": "/Incidents/Comment"
-                                        }
-                                    }
-                                }
-                            },
-                            "expression": {
-                                "and": [
-                                    {
-                                        "greater": [
-                                            "@length(variables('action results'))",
-                                            0
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "If"
+                                "actions": {}
+                            }
                         },
-                        "If_action_results_and_unknown_action_results": {
-                            "actions": {
-                                "Add_comment_to_incident_(V3)_-_known_and_unknown_action_results": {
-                                    "runAfter": {},
-                                    "type": "ApiConnection",
-                                    "inputs": {
-                                        "body": {
-                                            "incidentArmId": "@triggerBody()?['object']?['id']",
-                                            "message": "<p>QUARANTINE ACTION RESULTS<br>\n@{body('Create_HTML_table_of_action_results')}<br>\n<br>\n@{body('Create_HTML_table_of_unknown_action_results')}</p>"
-                                        },
-                                        "host": {
-                                            "connection": {
-                                                "name": "@parameters('$connections')['azuresentinel']['connectionId']"
-                                            }
-                                        },
-                                        "method": "post",
-                                        "path": "/Incidents/Comment"
-                                    }
-                                },
-                                "Terminate_2": {
-                                    "runAfter": {
-                                        "Add_comment_to_incident_(V3)_-_known_and_unknown_action_results": [
-                                            "Succeeded"
-                                        ]
-                                    },
-                                    "type": "Terminate",
-                                    "inputs": {
-                                        "runStatus": "Succeeded"
-                                    }
-                                }
-                            },
-                            "runAfter": {
-                                "Create_HTML_table_of_unknown_action_results": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "expression": {
-                                "and": [
-                                    {
-                                        "greater": [
-                                            "@length(variables('action results'))",
-                                            0
-                                        ]
-                                    },
-                                    {
-                                        "greater": [
-                                            "@length(variables('unknown action results'))",
-                                            0
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "If"
-                        },
-                        "If_macOS_endpoints": {
+                        "apply_quarantine_action_to_macOS_endpoints": {
                             "actions": {
                                 "Check_macOS_issued_action_result": {
                                     "actions": {
                                         "Append_macOS_issued_action_result_to_issued_actions": {
-                                            "runAfter": {},
                                             "type": "AppendToArrayVariable",
                                             "inputs": {
-                                                "name": "issued actions",
-                                                "value": "@body('Issue_macOS_action')?['data']"
+                                                "name": "issuedActions",
+                                                "value": "@body('Issue_macOS_Quarantine_action')?['data']"
                                             }
                                         }
                                     },
                                     "runAfter": {
-                                        "Issue_macOS_action": [
+                                        "Issue_macOS_Quarantine_action": [
                                             "Succeeded"
                                         ]
                                     },
@@ -1563,13 +883,16 @@
                                         "and": [
                                             {
                                                 "equals": [
-                                                    "@body('Issue_macOS_action')",
+                                                    "@body('Issue_macOS_Quarantine_action')",
                                                     200
                                                 ]
                                             }
                                         ]
                                     },
-                                    "type": "If"
+                                    "type": "If",
+                                    "else": {
+                                        "actions": {}
+                                    }
                                 },
                                 "Compose_macOS_action": {
                                     "runAfter": {
@@ -1580,11 +903,11 @@
                                     "type": "Compose",
                                     "inputs": {
                                         "action_group": {
-                                            "id": "@variables('all computers id')"
+                                            "id": "@variables('allComputersGroupId')"
                                         },
                                         "distribute_seconds": 0,
                                         "expire_seconds": "@body('Parse_macOS_package_json')?['data']?['expire_seconds']",
-                                        "name": "Apply from Microsoft Sentinel @{variables('macos package name')}",
+                                        "name": "Apply from Microsoft Sentinel @{variables('macOsPackageName')}",
                                         "package_spec": "@outputs('Compose_macOS_action_package_declaration')",
                                         "target_group": "@outputs('Compose_macOS_target_group')"
                                     }
@@ -1598,7 +921,7 @@
                                     "type": "Compose",
                                     "inputs": {
                                         "expire_seconds": "@body('Parse_macOS_package_json')?['data']?['expire_seconds']",
-                                        "parameters": "@variables('package parameters')",
+                                        "parameters": "@variables('packageParameters')",
                                         "source_id": "@body('Parse_macOS_package_json')?['data']?['id']"
                                     }
                                 },
@@ -1611,11 +934,10 @@
                                     "type": "Compose",
                                     "inputs": {
                                         "and_flag": false,
-                                        "sub_groups": "@variables('macos endpoint filters')"
+                                        "sub_groups": "@variables('macOsEndpointFilters')"
                                     }
                                 },
-                                "Get_macOS_package": {
-                                    "runAfter": {},
+                                "Get_macOS_Quarantine_package": {
                                     "type": "Http",
                                     "inputs": {
                                         "headers": {
@@ -1623,7 +945,7 @@
                                             "session": "@parameters('TaniumApiToken')"
                                         },
                                         "method": "GET",
-                                        "uri": "@{concat(parameters('TaniumPackagesByNameUrlFragment'), join(split(variables('macos package name'), ' '), '%20'))}"
+                                        "uri": "@{concat(parameters('TaniumPackagesByNameUrlFragment'), join(split(variables('macOsPackageName'), ' '), '%20'))}"
                                     },
                                     "runtimeConfiguration": {
                                         "secureData": {
@@ -1633,7 +955,7 @@
                                         }
                                     }
                                 },
-                                "Issue_macOS_action": {
+                                "Issue_macOS_Quarantine_action": {
                                     "runAfter": {
                                         "Compose_macOS_action": [
                                             "Succeeded"
@@ -1659,13 +981,13 @@
                                 },
                                 "Parse_macOS_package_json": {
                                     "runAfter": {
-                                        "Get_macOS_package": [
+                                        "Get_macOS_Quarantine_package": [
                                             "Succeeded"
                                         ]
                                     },
                                     "type": "ParseJson",
                                     "inputs": {
-                                        "content": "@body('Get_macOS_package')",
+                                        "content": "@body('Get_macOS_Quarantine_package')",
                                         "schema": {
                                             "properties": {
                                                 "data": {
@@ -1776,7 +1098,7 @@
                                 }
                             },
                             "runAfter": {
-                                "If_Windows_endpoints": [
+                                "Generate_the_endpoints_filters_for_each_OS_package": [
                                     "Succeeded"
                                 ]
                             },
@@ -1784,17 +1106,20 @@
                                 "and": [
                                     {
                                         "greater": [
-                                            "@length(variables('macos endpoint filters'))",
+                                            "@length(variables('macOsEndpointFilters'))",
                                             0
                                         ]
                                     }
                                 ]
                             },
-                            "type": "If"
+                            "type": "If",
+                            "else": {
+                                "actions": {}
+                            }
                         },
-                        "Initialize_API_Gateway_Query": {
+                        "Initialize_API_Query": {
                             "runAfter": {
-                                "Initialize_package_parameters": [
+                                "Exit_early_if_incident_has_no_hosts": [
                                     "Succeeded"
                                 ]
                             },
@@ -1802,132 +1127,18 @@
                             "inputs": {
                                 "variables": [
                                     {
-                                        "name": "api gateway query",
+                                        "name": "apiQuery",
                                         "type": "string",
                                         "value": "query ($incidentHosts: EndpointFieldFilter, $endCursor: Cursor, $source: EndpointSource) {\n  endpoints(\n    source: $source\n    first: 10\n    after: $endCursor\n    filter: $incidentHosts\n  ) {\n    edges {\n      node {\n        name\n        ipAddress\n        os { platform }\n      }\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}"
                                     }
                                 ]
                             }
                         },
-                        "Initialize_API_Gateway_Query_Variables": {
+                        "Initialize_API_Variables": {
                             "runAfter": {
-                                "Initialize_Tanium_Endpoint_Source_to_TDS": [
+                                "Initialize_Endpoint_Source_to_TDS": [
                                     "Succeeded"
-                                ]
-                            },
-                            "type": "InitializeVariable",
-                            "inputs": {
-                                "variables": [
-                                    {
-                                        "name": "api gateway query variables",
-                                        "type": "string",
-                                        "value": "{\n  \"source\": @{variables('Tanium Endpoint Source')},\n  \"incidentHosts\": {\n    \"any\": true,\n    \"filters\": @{variables('endpoint filters')}\n  }\n}"
-                                    }
-                                ]
-                            }
-                        },
-                        "Initialize_API_Gateway_Response": {
-                            "runAfter": {
-                                "Query_API_Gateway": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "InitializeVariable",
-                            "inputs": {
-                                "variables": [
-                                    {
-                                        "name": "API Gateway Response",
-                                        "type": "object",
-                                        "value": "@body('Query_API_Gateway')"
-                                    }
-                                ]
-                            }
-                        },
-                        "Initialize_API_Gateway_query_cursor": {
-                            "runAfter": {
-                                "Stop_If_Tanium_Has_No_Hosts_From_Incident": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "InitializeVariable",
-                            "inputs": {
-                                "variables": [
-                                    {
-                                        "name": "cursor",
-                                        "type": "string",
-                                        "value": "@body('Parse_API_Gateway_response')?['data']?['endpoints']?['pageInfo']?['endCursor']"
-                                    }
-                                ]
-                            }
-                        },
-                        "Initialize_Endpoint_Filter": {
-                            "runAfter": {
-                                "Initialize_API_Gateway_Query": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "InitializeVariable",
-                            "inputs": {
-                                "variables": [
-                                    {
-                                        "name": "endpoint filters",
-                                        "type": "array"
-                                    }
-                                ]
-                            }
-                        },
-                        "Initialize_Linux_endpoint_filters": {
-                            "runAfter": {
-                                "Initialize_Windows_endpoint_filters": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "InitializeVariable",
-                            "inputs": {
-                                "variables": [
-                                    {
-                                        "name": "linux endpoint filters",
-                                        "type": "array"
-                                    }
-                                ]
-                            }
-                        },
-                        "Initialize_Linux_package_name": {
-                            "runAfter": {
-                                "Initialize_MacOS_package_name": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "InitializeVariable",
-                            "inputs": {
-                                "variables": [
-                                    {
-                                        "name": "linux package name",
-                                        "type": "string",
-                                        "value": "Apply Linux IPTables Quarantine"
-                                    }
-                                ]
-                            }
-                        },
-                        "Initialize_MacOS_package_name": {
-                            "runAfter": {
-                                "Initialize_Windows_package_name": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "InitializeVariable",
-                            "inputs": {
-                                "variables": [
-                                    {
-                                        "name": "macos package name",
-                                        "type": "string",
-                                        "value": "Apply Mac PF Quarantine"
-                                    }
-                                ]
-                            }
-                        },
-                        "Initialize_Tanium_Endpoint_Source_to_TDS": {
-                            "runAfter": {
+                                ],
                                 "Set_Endpoint_Filter": [
                                     "Succeeded"
                                 ]
@@ -1936,51 +1147,16 @@
                             "inputs": {
                                 "variables": [
                                     {
-                                        "name": "tanium endpoint source",
-                                        "type": "object",
-                                        "value": {
-                                            "tds": {}
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Initialize_Windows_endpoint_filters": {
-                            "runAfter": {
-                                "Add_comment_to_incident_-_hosts_that_will_be_targeted": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "InitializeVariable",
-                            "inputs": {
-                                "variables": [
-                                    {
-                                        "name": "windows endpoint filters",
-                                        "type": "array"
-                                    }
-                                ]
-                            }
-                        },
-                        "Initialize_Windows_package_name": {
-                            "runAfter": {
-                                "Exit_early_if_no_hosts_are_found": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "InitializeVariable",
-                            "inputs": {
-                                "variables": [
-                                    {
-                                        "name": "windows package name",
+                                        "name": "apiVariables",
                                         "type": "string",
-                                        "value": "Apply Windows IPsec Quarantine"
+                                        "value": "{\n  \"source\": @{variables('endpointSource')},\n  \"incidentHosts\": {\n    \"any\": true,\n    \"filters\": @{variables('endpointFilters')}\n  }\n}"
                                     }
                                 ]
                             }
                         },
-                        "Initialize_action_results": {
+                        "Initialize_Endpoint_Filter": {
                             "runAfter": {
-                                "Wait_for_the_max_expire_seconds_from_the_issued_actions": [
+                                "Exit_early_if_incident_has_no_hosts": [
                                     "Succeeded"
                                 ]
                             },
@@ -1988,15 +1164,15 @@
                             "inputs": {
                                 "variables": [
                                     {
-                                        "name": "action results",
+                                        "name": "endpointFilters",
                                         "type": "array"
                                     }
                                 ]
                             }
                         },
-                        "Initialize_all_computers_id": {
+                        "Initialize_the_filter_for_Linux_endpoint(s)": {
                             "runAfter": {
-                                "Get_the_\"All_Computers\"_group": [
+                                "Initialize_the_name_of_the_Linux_quarantine_package": [
                                     "Succeeded"
                                 ]
                             },
@@ -2004,49 +1180,15 @@
                             "inputs": {
                                 "variables": [
                                     {
-                                        "name": "all computers id",
-                                        "type": "string",
-                                        "value": "@{body('Get_the_\"All_Computers\"_group')?['data']?['id']}"
-                                    }
-                                ]
-                            }
-                        },
-                        "Initialize_endpoints_array": {
-                            "runAfter": {
-                                "Initialize_API_Gateway_query_cursor": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "InitializeVariable",
-                            "inputs": {
-                                "variables": [
-                                    {
-                                        "name": "endpoints",
-                                        "type": "array",
-                                        "value": "@body('Parse_API_Gateway_response')?['data']?['endpoints']?['edges']"
-                                    }
-                                ]
-                            }
-                        },
-                        "Initialize_issued_actions": {
-                            "runAfter": {
-                                "Initialize_macOS_endpoint_filters": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "InitializeVariable",
-                            "inputs": {
-                                "variables": [
-                                    {
-                                        "name": "issued actions",
+                                        "name": "linuxEndpointFilters",
                                         "type": "array"
                                     }
                                 ]
                             }
                         },
-                        "Initialize_macOS_endpoint_filters": {
+                        "Initialize_Endpoint_Source_to_TDS": {
                             "runAfter": {
-                                "Initialize_Linux_endpoint_filters": [
+                                "Exit_early_if_incident_has_no_hosts": [
                                     "Succeeded"
                                 ]
                             },
@@ -2054,15 +1196,31 @@
                             "inputs": {
                                 "variables": [
                                     {
-                                        "name": "macos endpoint filters",
+                                        "name": "endpointSource",
+                                        "type": "object"
+                                    }
+                                ]
+                            }
+                        },
+                        "Initialize_the_filter_for_Windows_endpoint(s)": {
+                            "runAfter": {
+                                "Initialize_the_name_of_the_Windows_quarantine_package": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "InitializeVariable",
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "windowsEndpointFilters",
                                         "type": "array"
                                     }
                                 ]
                             }
                         },
-                        "Initialize_package_parameters": {
+                        "Initialize_all_computers_group's_id": {
                             "runAfter": {
-                                "Initialize_Linux_package_name": [
+                                "Get_information_about_incident_hosts_from_Tanium": [
                                     "Succeeded"
                                 ]
                             },
@@ -2070,7 +1228,72 @@
                             "inputs": {
                                 "variables": [
                                     {
-                                        "name": "package parameters",
+                                        "name": "allComputersGroupId",
+                                        "type": "string"
+                                    }
+                                ]
+                            }
+                        },
+                        "Initialize_list_of_issued_actions": {
+                            "runAfter": {
+                                "Get_information_about_incident_hosts_from_Tanium": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "InitializeVariable",
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "issuedActions",
+                                        "type": "array"
+                                    }
+                                ]
+                            }
+                        },
+                        "Initialize_the_filter_for_macOS_endpoint(s)": {
+                            "runAfter": {
+                                "Initialize_the_name_of_the_MacOS_quarantine_package": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "InitializeVariable",
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "macOsEndpointFilters",
+                                        "type": "array"
+                                    }
+                                ]
+                            }
+                        },
+                        "Initialize_list_of_unknown_action_results": {
+                            "runAfter": {
+                                "Get_information_about_incident_hosts_from_Tanium": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "InitializeVariable",
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "unknownActionResults",
+                                        "type": "array"
+                                    }
+                                ]
+                            }
+                        },
+                        "Initialize_quarantine_package_parameters": {
+                            "runAfter": {
+                                "Get_information_about_incident_hosts_from_Tanium": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "InitializeVariable",
+                            "description": "The quarantine packages use the same parameters across operating systems",
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "packageParameters",
                                         "type": "array",
                                         "value": [
                                             {
@@ -2112,12 +1335,11 @@
                                         ]
                                     }
                                 ]
-                            },
-                            "description": "The quarantine packages use the same parameters across operating systems"
+                            }
                         },
-                        "Initialize_unknown_action_results": {
+                        "Initialize_the_name_of_the_Linux_quarantine_package": {
                             "runAfter": {
-                                "Initialize_issued_actions": [
+                                "Get_information_about_incident_hosts_from_Tanium": [
                                     "Succeeded"
                                 ]
                             },
@@ -2125,51 +1347,119 @@
                             "inputs": {
                                 "variables": [
                                     {
-                                        "name": "unknown action results",
-                                        "type": "array"
+                                        "name": "linuxPackageName",
+                                        "type": "string",
+                                        "value": "Apply Linux IPTables Quarantine"
                                     }
                                 ]
                             }
                         },
-                        "Paginate_API_Gateway_query_if_needed": {
+                        "Initialize_the_name_of_the_Windows_quarantine_package": {
+                            "runAfter": {
+                                "Get_information_about_incident_hosts_from_Tanium": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "windowsPackageName",
+                                        "type": "string",
+                                        "value": "Apply Windows IPsec Quarantine"
+                                    }
+                                ]
+                            },
+                            "type": "InitializeVariable"
+
+                        },
+                        "Initialize_the_name_of_the_MacOS_quarantine_package": {
+                            "runAfter": {
+                                "Get_information_about_incident_hosts_from_Tanium": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "macOsPackageName",
+                                        "type": "string",
+                                        "value": "Apply Mac PF Quarantine"
+                                    }
+                                ]
+                            },
+                            "type": "InitializeVariable"
+
+                        },
+                        "Initialize_API_Response": {
+                            "runAfter": {
+                                "Exit_early_if_incident_has_no_hosts": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "apiResponse",
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "type": "InitializeVariable"
+
+                        },
+                        "Get_information_about_incident_hosts_from_Tanium": {
+                            "type": "Scope",
+                            "description": "Gets the information about the incident hosts from Tanium and adds a comment to sentinel listing the host to be targeted",
                             "actions": {
-                                "Until_there_are_no_more_pages_in_the_API_gateway_response": {
-                                    "actions": {
-                                        "For_each_endpoint_in_paginated_API_Gateway_response": {
-                                            "foreach": "@body('Parse_paginated_API_Gateway_response')?['data']?['endpoints']?['edges']",
-                                            "actions": {
-                                                "Append_endpoint_to_endpoints": {
-                                                    "runAfter": {},
-                                                    "type": "AppendToArrayVariable",
-                                                    "inputs": {
-                                                        "name": "endpoints",
-                                                        "value": "@items('For_each_endpoint_in_paginated_API_Gateway_response')"
-                                                    }
-                                                }
-                                            },
-                                            "runAfter": {
-                                                "Update_API_Gateway_query_cursor": [
-                                                    "Succeeded"
-                                                ]
-                                            },
-                                            "type": "Foreach",
-                                            "runtimeConfiguration": {
-                                                "concurrency": {
-                                                    "repetitions": 1
-                                                }
-                                            }
+                                "Get_General_Host_Info": {
+                                    "type": "Http",
+                                    "description": "Get information about the incident hosts from Tanium.",
+                                    "inputs": {
+                                        "body": {
+                                            "query": "@variables('apiQuery')",
+                                            "variables": "@json(variables('apiVariables'))"
                                         },
-                                        "Paginate_API_Gateway": {
+                                        "headers": {
+                                            "Content-Type": "application/json",
+                                            "session": "@parameters('TaniumApiToken')"
+                                        },
+                                        "uri": "@parameters('TaniumApiGatewayApi')",
+                                        "method": "POST"
+                                    },
+                                    "runtimeConfiguration": {
+                                        "secureData": {
+                                            "properties": [
+                                                "inputs"
+                                            ]
+                                        }
+                                    }
+                                },
+                                "Set_apiResponse": {
+                                    "runAfter": {
+                                        "Get_General_Host_Info": [
+                                            "Succeeded"
+                                        ]
+                                    },
+                                    "type": "SetVariable",
+                                    "inputs": {
+                                        "name": "apiResponse",
+                                        "value": "@body('Get_General_Host_Info')"
+                                    }
+                                },
+                                "Switch_to_TS_from_TDS_if_needed": {
+                                    "description": "Switch from asking the Tanium Server for information to using the Tanium Data Service.",
+                                    "actions": {
+                                        "Requery_the_API_Gateway": {
                                             "runAfter": {
-                                                "Update_API_Gateway_query_variables": [
+                                                "Update_API_Query_variables_to_get_new_source": [
                                                     "Succeeded"
                                                 ]
                                             },
                                             "type": "Http",
                                             "inputs": {
                                                 "body": {
-                                                    "query": "@variables('api gateway query')",
-                                                    "variables": "@json(variables('api gateway query variables'))"
+                                                    "query": "@variables('apiQuery')",
+                                                    "variables": "@json(variables('apiVariables'))"
                                                 },
                                                 "headers": {
                                                     "Content-Type": "application/json",
@@ -2186,45 +1476,536 @@
                                                 }
                                             }
                                         },
-                                        "Parse_paginated_API_Gateway_response": {
+                                        "Change_Endpoint_Source_to_TS": {
+                                            "type": "SetVariable",
+                                            "inputs": {
+                                                "name": "endpointSource",
+                                                "value": {
+                                                    "ts": {
+                                                        "stableWaitTime": 30
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "Update_API_Gateway_Response": {
                                             "runAfter": {
-                                                "Paginate_API_Gateway": [
+                                                "Requery_the_API_Gateway": [
                                                     "Succeeded"
                                                 ]
                                             },
-                                            "type": "ParseJson",
+                                            "type": "SetVariable",
                                             "inputs": {
-                                                "content": "@body('Paginate_API_Gateway')",
-                                                "schema": {
+                                                "name": "apiResponse",
+                                                "value": "@body('Requery_the_API_Gateway')"
+                                            }
+                                        },
+                                        "Update_API_Query_variables_to_get_new_source": {
+                                            "runAfter": {
+                                                "Change_Endpoint_Source_to_TS": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "SetVariable",
+                                            "inputs": {
+                                                "name": "apiVariables",
+                                                "value": "{\n  \"source\": @{variables('endpointSource')},\n  \"incidentHosts\": {\n    \"any\": true,\n    \"filters\": @{variables('endpointFilters')}\n  }\n}"
+                                            }
+                                        }
+                                    },
+                                    "runAfter": {
+                                        "Set_apiResponse": [
+                                            "Succeeded"
+                                        ]
+                                    },
+                                    "expression": {
+                                        "and": [
+                                            {
+                                                "contains": [
+                                                    "@string(body('Get_General_Host_Info'))",
+                                                    "must refer to an existing sensor"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "type": "If",
+                                    "else": {
+                                        "actions": {}
+                                    }
+                                },
+                                "Parse_API_response": {
+                                    "runAfter": {
+                                        "Switch_to_TS_from_TDS_if_needed": [
+                                            "Succeeded"
+                                        ]
+                                    },
+                                    "type": "ParseJson",
+                                    "inputs": {
+                                        "content": "@variables('apiResponse')",
+                                        "schema": {
+                                            "properties": {
+                                                "data": {
                                                     "properties": {
-                                                        "data": {
+                                                        "endpoints": {
                                                             "properties": {
-                                                                "endpoints": {
-                                                                    "properties": {
-                                                                        "edges": {
-                                                                            "items": {
-                                                                                "properties": {
-                                                                                    "node": {
-                                                                                        "type": "object"
-                                                                                    }
-                                                                                },
-                                                                                "required": [
-                                                                                    "node"
-                                                                                ],
+                                                                "edges": {
+                                                                    "items": {
+                                                                        "properties": {
+                                                                            "node": {
                                                                                 "type": "object"
-                                                                            },
-                                                                            "type": "array"
+                                                                            }
                                                                         },
-                                                                        "pageInfo": {
+                                                                        "required": [
+                                                                            "node"
+                                                                        ],
+                                                                        "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                },
+                                                                "pageInfo": {
+                                                                    "properties": {
+                                                                        "endCursor": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "hasNextPage": {
+                                                                            "type": "boolean"
+                                                                        }
+                                                                    },
+                                                                    "type": "object"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                },
+                                                "errors": {
+                                                    "items": {
+                                                        "properties": {
+                                                            "message": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "message"
+                                                        ],
+                                                        "type": "object"
+                                                    },
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    }
+                                },
+                                "Exit_early_If_Tanium_Has_No_Data_for_Incident": {
+                                    "actions": {
+                                        "Add_comment__-_no_data_in_Tanium": {
+                                            "type": "ApiConnection",
+                                            "inputs": {
+                                                "body": {
+                                                    "incidentArmId": "@triggerBody()?['object']?['id']",
+                                                    "message": "<p>No data found in Tanium for hosts.</p>"
+                                                },
+                                                "host": {
+                                                    "connection": {
+                                                        "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                                    }
+                                                },
+                                                "method": "post",
+                                                "path": "/Incidents/Comment"
+                                            }
+                                        },
+                                        "Exit_early__-_no_data_in_Tanium": {
+                                            "runAfter": {
+                                                "Add_comment__-_no_data_in_Tanium": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "Terminate",
+                                            "inputs": {
+                                                "runStatus": "Succeeded"
+                                            }
+                                        }
+                                    },
+                                    "runAfter": {
+                                        "Parse_API_response": [
+                                            "Succeeded"
+                                        ]
+                                    },
+                                    "expression": {
+                                        "and": [
+                                            {
+                                                "equals": [
+                                                    "@body('Parse_API_response')?['data']?['endpoints']?['pageInfo']?['endCursor']",
+                                                    "@null"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "type": "If",
+                                    "else": {
+                                        "actions": {}
+                                    }
+                                },
+                                "Set_endpoints_list": {
+                                    "runAfter": {
+                                        "Exit_early_If_Tanium_Has_No_Data_for_Incident": [
+                                            "Succeeded"
+                                        ]
+                                    },
+                                    "type": "SetVariable",
+                                    "inputs": {
+                                        "name": "endpoints",
+                                        "value": "@body('Parse_API_response')?['data']?['endpoints']?['edges']"
+                                    }
+                                },
+                                "Loop_Paginated_Response_if_has_multiple_pages": {
+
+                                    "actions": {
+                                        "Until_no_more_pages": {
+                                            "type": "Until",
+                                            "expression": "@equals(body('Parse_page')?['data']?['endpoints']?['pageInfo']?['hasNextPage'],false)",
+                                            "limit": {
+                                                "count": 60,
+                                                "timeout": "PT1H"
+                                            },
+                                            "actions": {
+                                                "For_each_endpoint_in_paginated_API_Gateway_response": {
+                                                    "type": "Foreach",
+                                                    "foreach": "@body('Parse_page')?['data']?['endpoints']?['edges']",
+                                                    "actions": {
+                                                        "Append_endpoint_to_endpoints": {
+                                                            "type": "AppendToArrayVariable",
+                                                            "inputs": {
+                                                                "name": "endpoints",
+                                                                "value": "@items('For_each_endpoint_in_paginated_API_Gateway_response')"
+                                                            }
+                                                        }
+                                                    },
+                                                    "runAfter": {
+                                                        "Update_cursor_to_next_page": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
+                                                    "runtimeConfiguration": {
+                                                        "concurrency": {
+                                                            "repetitions": 1
+                                                        }
+                                                    }
+                                                },
+                                                "Get_next_page": {
+                                                    "runAfter": {
+                                                        "Update_cursor_for_next_page": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
+                                                    "type": "Http",
+                                                    "inputs": {
+                                                        "uri": "@parameters('TaniumApiGatewayApi')",
+                                                        "method": "POST",
+                                                        "headers": {
+                                                            "Content-Type": "application/json",
+                                                            "session": "@parameters('TaniumApiToken')"
+                                                        },
+                                                        "body": {
+                                                            "query": "@variables('apiQuery')",
+                                                            "variables": "@json(variables('apiVariables'))"
+                                                        }
+                                                    },
+                                                    "runtimeConfiguration": {
+                                                        "secureData": {
+                                                            "properties": [
+                                                                "inputs"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "Parse_page": {
+                                                    "type": "ParseJson",
+                                                    "inputs": {
+                                                        "content": "@body('Get_next_page')",
+                                                        "schema": {
+                                                            "properties": {
+                                                                "data": {
+                                                                    "properties": {
+                                                                        "endpoints": {
                                                                             "properties": {
-                                                                                "endCursor": {
-                                                                                    "type": "string"
+                                                                                "edges": {
+                                                                                    "items": {
+                                                                                        "properties": {
+                                                                                            "node": {
+                                                                                                "type": "object"
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "node"
+                                                                                        ],
+                                                                                        "type": "object"
+                                                                                    },
+                                                                                    "type": "array"
                                                                                 },
-                                                                                "hasNextPage": {
-                                                                                    "type": "boolean"
+                                                                                "pageInfo": {
+                                                                                    "properties": {
+                                                                                        "endCursor": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "hasNextPage": {
+                                                                                            "type": "boolean"
+                                                                                        }
+                                                                                    },
+                                                                                    "type": "object"
                                                                                 }
                                                                             },
                                                                             "type": "object"
+                                                                        }
+                                                                    },
+                                                                    "type": "object"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        }
+                                                    },
+                                                    "runAfter": {
+                                                        "Get_next_page": [
+                                                            "Succeeded"
+                                                        ]
+                                                    }
+                                                },
+                                                "Update_cursor_to_next_page": {
+                                                    "type": "SetVariable",
+                                                    "inputs": {
+                                                        "name": "cursor",
+                                                        "value": "@body('Parse_page')?['data']?['endpoints']?['pageInfo']?['endCursor']"
+                                                    },
+                                                    "runAfter": {
+                                                        "Parse_page": [
+                                                            "Succeeded"
+                                                        ]
+                                                    }
+                                                },
+                                                "Update_cursor_for_next_page": {
+                                                    "type": "SetVariable",
+                                                    "inputs": {
+                                                        "name": "apiVariables",
+                                                        "value": {
+                                                            "source": "@variables('endpointSource')",
+                                                            "endCursor": ""
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "runAfter": {
+                                        "Set_endpoints_list": [
+                                            "Succeeded"
+                                        ],
+                                        "Set_cursor": [
+                                            "Succeeded"
+                                        ]
+                                    },
+                                    "expression": {
+                                        "and": [
+                                            {
+                                                "equals": [
+                                                    "@body('Parse_API_response')?['data']?['endpoints']?['pageInfo']?['hasNextPage']",
+                                                    "@true"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "type": "If",
+                                    "else": {
+                                        "actions": {}
+                                    }
+                                },
+                                "Parse_the_array_endpoints": {
+                                    "runAfter": {
+                                        "Loop_Paginated_Response_if_has_multiple_pages": [
+                                            "Succeeded"
+                                        ]
+                                    },
+                                    "type": "ParseJson",
+                                    "description": "We need an action's output to use in the JavaScript code since it can't read from a variable",
+                                    "inputs": {
+                                        "content": "@variables('endpoints')",
+                                        "schema": {
+                                            "type": "array"
+                                        }
+                                    }
+                                },
+                                "Flatten_API_Gateway_endpoints": {
+                                    "runAfter": {
+                                        "Parse_the_array_endpoints": [
+                                            "Succeeded"
+                                        ]
+                                    },
+                                    "type": "JavaScriptCode",
+                                    "inputs": {
+                                        "code": "var e = workflowContext.actions.Parse_the_array_endpoints.outputs.body;\r\n\r\nfunction sensorReadings(r) {\r\n\treturn r.columns.map(c => {\r\n\t\tif (c.sensor && c.sensor.name) {\r\n\t\t\treturn { name: [c.sensor.name, c.name].join(' - '), value: c.values.join(' ') };\r\n\t\t} else {\r\n\t\t\treturn { name: c.name, value: c.values.join(' ') };\r\n\t\t}\r\n\t});\r\n}\r\n\r\nfunction flatten(obj, pk = '') {\r\n\tif (pk !== '') pk += ' ';\r\n\tvar flat = {};\r\n\tObject.keys(obj).forEach((key) => {\r\n\t\tif (key === 'sensorReadings') {\r\n\t\t\tsensorReadings(obj[key]).forEach((r) => {\r\n\t\t\t\tflat[r.name] = r.value;\r\n\t\t\t});\r\n\t\t} else {\r\n\t\t\tif (typeof obj[key] === 'object' && obj[key] !== null) {\r\n\t\t\t\tObject.assign(flat, flatten(obj[key], pk + key));\r\n\t\t\t} else {\r\n\t\t\t\tflat[pk + key] = obj[key];\r\n\t\t\t}\r\n\t\t}\r\n\t});\r\n\treturn flat;\r\n}\r\n\r\nreturn e.map(function(e) { return flatten(e.node); });"
+                                    }
+                                },
+                                "Create_HTML_table_of_matched_endpoints": {
+                                    "runAfter": {
+                                        "Flatten_API_Gateway_endpoints": [
+                                            "Succeeded"
+                                        ]
+                                    },
+                                    "type": "Table",
+                                    "inputs": {
+                                        "from": "@body('Flatten_API_Gateway_endpoints')",
+                                        "format": "HTML"
+                                    }
+                                },
+                                "Add_comment_to_incident_-_hosts_that_will_be_targeted": {
+                                    "runAfter": {
+                                        "Create_HTML_table_of_matched_endpoints": [
+                                            "Succeeded"
+                                        ]
+                                    },
+                                    "type": "ApiConnection",
+                                    "inputs": {
+                                        "body": {
+                                            "incidentArmId": "@triggerBody()?['object']?['id']",
+                                            "message": "<p>Preparing to issue quarantine actions targeting these endpoints associated with this incident<br>\n@{body('Create_HTML_table_of_matched_endpoints')}</p>"
+                                        },
+                                        "host": {
+                                            "connection": {
+                                                "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                            }
+                                        },
+                                        "method": "post",
+                                        "path": "/Incidents/Comment"
+                                    }
+                                },
+                                "Set_cursor": {
+                                    "runAfter": {
+                                        "Exit_early_If_Tanium_Has_No_Data_for_Incident": [
+                                            "Succeeded"
+                                        ]
+                                    },
+                                    "type": "SetVariable",
+                                    "inputs": {
+                                        "name": "cursor",
+                                        "value": "@body('Parse_API_response')?['data']?['endpoints']?['pageInfo']?['endCursor']"
+                                    }
+                                }
+                            },
+                            "runAfter": {
+                                "Initialize_API_Query": [
+                                    "Succeeded"
+                                ],
+                                "Initialize_endpoints_array": [
+                                    "Succeeded"
+                                ],
+                                "Initialize_API_Variables": [
+                                    "Succeeded"
+                                ],
+                                "Initialize_cursor": [
+                                    "Succeeded"
+                                ]
+                            }
+                        },
+                        "Initialize_endpoints_array": {
+                            "runAfter": {
+                                "Exit_early_if_incident_has_no_hosts": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "InitializeVariable",
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "endpoints",
+                                        "type": "array"
+                                    }
+                                ]
+                            }
+                        },
+                        "Initialize_cursor": {
+                            "runAfter": {
+                                "Initialize_API_Response": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "InitializeVariable",
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "cursor",
+                                        "type": "string"
+                                    }
+                                ]
+                            }
+                        },
+                        "Set_allComputersGroupId": {
+                            "runAfter": {
+                                "Get_the_\"All_Computers\"_group": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "SetVariable",
+                            "inputs": {
+                                "name": "allComputersGroupId",
+                                "value": "@body('Get_the_\"All_Computers\"_group')?['data']?['id']"
+                            }
+                        },
+                        "Generate_the_endpoints_filters_for_each_OS_package": {
+                            "type": "Scope",
+                            "description": "Generates a filter each for Windows, Mac & Linux to be used by our requests to apply the quarantine package to the endpoints",
+                            "actions": {
+                                "For_each_host_on_the_incident": {
+                                    "type": "Foreach",
+                                    "description": "Loop through each host that was on the incident and where Tanium had data about the host",
+                                    "foreach": "@variables('endpoints')",
+                                    "actions": {
+                                        "Compose_endpoint_filter_for_packages": {
+                                            "description": "Compose the filter for the current incident host to be used to get the quarantine package",
+                                            "runAfter": {
+                                                "Parse_endpoint_JSON_data": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "Compose",
+                                            "inputs": {
+                                                "and_flag": true,
+                                                "filters": [
+                                                    {
+                                                        "operator": "Equal",
+                                                        "sensor": {
+                                                            "name": "Computer Name"
+                                                        },
+                                                        "value": "@body('Parse_endpoint_JSON_data')?['node']?['name']"
+                                                    },
+                                                    {
+                                                        "operator": "RegexMatch",
+                                                        "sensor": {
+                                                            "name": "IP Address"
+                                                        },
+                                                        "value": "@body('Parse_endpoint_JSON_data')?['node']?['ipAddress']"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "Parse_endpoint_JSON_data": {
+                                            "type": "ParseJson",
+                                            "description": "Parse the information received from Tanium",
+                                            "inputs": {
+                                                "content": "@items('For_each_host_on_the_incident')",
+                                                "schema": {
+                                                    "properties": {
+                                                        "node": {
+                                                            "properties": {
+                                                                "ipAddress": {
+                                                                    "type": "string"
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                },
+                                                                "os": {
+                                                                    "properties": {
+                                                                        "platform": {
+                                                                            "type": "string"
                                                                         }
                                                                     },
                                                                     "type": "object"
@@ -2237,90 +2018,437 @@
                                                 }
                                             }
                                         },
-                                        "Update_API_Gateway_query_cursor": {
+                                        "Switch": {
+                                            "type": "Switch",
+                                            "expression": "@body('Parse_endpoint_JSON_data')?['node']?['os']?['platform']",
+                                            "default": {
+                                                "actions": {}
+                                            },
+                                            "cases": {
+                                                "Linux": {
+                                                    "actions": {
+                                                        "Append_to_Linux_endpoint_filters": {
+                                                            "type": "AppendToArrayVariable",
+                                                            "inputs": {
+                                                                "name": "linuxEndpointFilters",
+                                                                "value": "@outputs('Compose_endpoint_filter_for_packages')"
+                                                            }
+                                                        }
+                                                    },
+                                                    "case": "Linux"
+                                                },
+                                                "Mac": {
+                                                    "actions": {
+                                                        "Append_to_macOS_endpoint_filters": {
+                                                            "type": "AppendToArrayVariable",
+                                                            "inputs": {
+                                                                "name": "macOsEndpointFilters",
+                                                                "value": "@outputs('Compose_endpoint_filter_for_packages')"
+                                                            }
+                                                        }
+                                                    },
+                                                    "case": "Mac"
+                                                },
+                                                "Windows": {
+                                                    "actions": {
+                                                        "Append_to_Windows_endpoint_filters": {
+                                                            "type": "AppendToArrayVariable",
+                                                            "inputs": {
+                                                                "name": "windowsEndpointFilters",
+                                                                "value": "@outputs('Compose_endpoint_filter_for_packages')"
+                                                            }
+                                                        }
+                                                    },
+                                                    "case": "Windows"
+                                                }
+                                            },
                                             "runAfter": {
-                                                "Parse_paginated_API_Gateway_response": [
+                                                "Compose_endpoint_filter_for_packages": [
                                                     "Succeeded"
                                                 ]
-                                            },
-                                            "type": "SetVariable",
-                                            "inputs": {
-                                                "name": "cursor",
-                                                "value": "@body('Parse_paginated_API_Gateway_response')?['data']?['endpoints']?['pageInfo']?['endCursor']"
-                                            }
-                                        },
-                                        "Update_API_Gateway_query_variables": {
-                                            "runAfter": {},
-                                            "type": "SetVariable",
-                                            "inputs": {
-                                                "name": "api gateway query variables",
-                                                "value": "{\n  \"source\": @{variables('tanium endpoint source')},\n  \"endCursor\": \"@{variables('cursor')}\"\n}"
                                             }
                                         }
-                                    },
-                                    "runAfter": {},
-                                    "expression": "@equals(body('Parse_paginated_API_Gateway_response')?['data']?['endpoints']?['pageInfo']?['hasNextPage'], false)",
-                                    "limit": {
-                                        "count": 60,
-                                        "timeout": "PT1H"
-                                    },
-                                    "type": "Until"
+                                    }
                                 }
                             },
                             "runAfter": {
-                                "Initialize_endpoints_array": [
+                                "Set_allComputersGroupId": [
                                     "Succeeded"
                                 ]
-                            },
-                            "expression": {
-                                "and": [
+                            }
+                        },
+                        "Initialize_action_results": {
+                            "type": "InitializeVariable",
+                            "inputs": {
+                                "variables": [
                                     {
-                                        "equals": [
-                                            "@body('Parse_API_Gateway_response')?['data']?['endpoints']?['pageInfo']?['hasNextPage']",
-                                            "@true"
-                                        ]
+                                        "name": "knownActionResults",
+                                        "type": "array"
                                     }
                                 ]
                             },
-                            "type": "If"
-                        },
-                        "Parse_API_Gateway_response": {
                             "runAfter": {
-                                "Switch_to_TS_from_TDS_if_needed": [
+                                "Exit_early_if_no_quarantine_actions_were_successfully_issued": [
                                     "Succeeded"
                                 ]
-                            },
-                            "type": "ParseJson",
-                            "inputs": {
-                                "content": "@variables('API Gateway Response')",
-                                "schema": {
-                                    "properties": {
-                                        "data": {
-                                            "properties": {
-                                                "endpoints": {
-                                                    "properties": {
-                                                        "edges": {
-                                                            "items": {
-                                                                "properties": {
-                                                                    "node": {
-                                                                        "properties": {},
-                                                                        "type": "object"
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "node"
-                                                                ],
-                                                                "type": "object"
-                                                            },
-                                                            "type": "array"
+                            }
+                        },
+                        "Check_results_of_quarantine_action": {
+                            "type": "Scope",
+                            "actions": {
+                                "Select_expire_seconds": {
+                                    "type": "Select",
+                                    "inputs": {
+                                        "from": "@variables('issuedActions')",
+                                        "select": "@int(item()?['expire_seconds'])"
+                                    }
+                                },
+                                "Wait_for_the_max_expire_seconds_from_the_issued_actions": {
+                                    "type": "Wait",
+                                    "inputs": {
+                                        "interval": {
+                                            "count": "@max(body('Select_expire_seconds'))",
+                                            "unit": "Second"
+                                        }
+                                    },
+                                    "runAfter": {
+                                        "Select_expire_seconds": [
+                                            "SUCCEEDED"
+                                        ]
+                                    }
+                                },
+                                "Collect_action_results_for_each_issued_action": {
+                                    "type": "Foreach",
+                                    "foreach": "@variables('issuedActions')",
+                                    "actions": {
+                                        "Get_action_result": {
+                                            "type": "Http",
+                                            "inputs": {
+                                                "uri": "@{concat(parameters('TaniumActionResultDataUrlFragment'), items('Collect_action_results_for_each_issued_action')?['id'])}",
+                                                "method": "GET",
+                                                "headers": {
+                                                    "Content-Type": "application/json",
+                                                    "session": "@parameters('TaniumApiToken')"
+                                                },
+                                                "runtimeConfiguration": {
+                                                    "secureData": {
+                                                        "properties": [
+                                                            "inputs"
+                                                        ]
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "If_action_result_could_be_determined": {
+                                            "type": "If",
+                                            "expression": {
+                                                "and": [
+                                                    {
+                                                        "greater": [
+                                                            "@length(outputs('Parse_action_result')['body'])",
+                                                            0
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "actions": {
+                                                "For_each_action_result_set": {
+                                                    "type": "Foreach",
+                                                    "foreach": "@body('Parse_action_result')",
+                                                    "actions": {
+                                                        "Append_to_action_results": {
+                                                            "type": "AppendToArrayVariable",
+                                                            "inputs": {
+                                                                "name": "knownActionResults",
+                                                                "value": "@item()"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "else": {
+                                                "actions": {
+                                                    "Append_to_unknown_action_results": {
+                                                        "type": "AppendToArrayVariable",
+                                                        "inputs": {
+                                                            "name": "unknownActionResults",
+                                                            "value": "@outputs('Compose_unknown_action_result')"
                                                         },
-                                                        "pageInfo": {
+                                                        "runAfter": {
+                                                            "Compose_unknown_action_result": [
+                                                                "Succeeded"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "Compose_unknown_action_result": {
+                                                        "type": "Compose",
+                                                        "inputs": {
+                                                            "action id": "@item()?['id']",
+                                                            "status": "Completed with unknown result"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "runAfter": {
+                                                "Parse_action_result": [
+                                                    "Succeeded"
+                                                ]
+                                            }
+                                        },
+                                        "Parse_action_result": {
+                                            "type": "JavaScriptCode",
+                                            "inputs": {
+                                                "code": "var action_results = workflowContext.actions.Get_action_result.outputs.body.data;\r\nvar action_id = workflowContext.actions.Parse_current_issued_action.outputs.body.id;\r\nvar columns = action_results.result_sets[0].columns.map(c => c.name);\r\nvar robjects = [];\r\n\r\naction_results.result_sets.forEach(function(rs) {\r\n\trs.rows.forEach(function(row) {\r\n\t\tvar robject = {'action id': action_id};\r\n\t\tcolumns.forEach(function(c, i) {\r\n\t\t\trobject[c] = row.data[i][0].text;\r\n\t\t});\r\n\t\trobjects.push(robject);\r\n\t});\r\n});\r\n\r\nreturn robjects;"
+                                            },
+                                            "runAfter": {
+                                                "Parse_current_issued_action": [
+                                                    "Succeeded"
+                                                ]
+                                            }
+                                        },
+                                        "Parse_current_issued_action": {
+                                            "type": "ParseJson",
+                                            "inputs": {
+                                                "content": "@items('Collect_action_results_for_each_issued_action')",
+                                                "schema": {
+                                                    "properties": {
+                                                        "action_group": {
                                                             "properties": {
-                                                                "endCursor": {
+                                                                "id": {
+                                                                    "type": "integer"
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "approver": {
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "integer"
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "comment": {
+                                                            "type": "string"
+                                                        },
+                                                        "creation_time": {
+                                                            "type": "string"
+                                                        },
+                                                        "distribute_seconds": {
+                                                            "type": "integer"
+                                                        },
+                                                        "expiration_time": {
+                                                            "type": "string"
+                                                        },
+                                                        "expire_seconds": {
+                                                            "type": "integer"
+                                                        },
+                                                        "history_saved_question": {
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "integer"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "id": {
+                                                            "type": "integer"
+                                                        },
+                                                        "name": {
+                                                            "type": "string"
+                                                        },
+                                                        "package_spec": {
+                                                            "properties": {
+                                                                "available_time": {
                                                                     "type": "string"
                                                                 },
-                                                                "hasNextPage": {
+                                                                "command": {
+                                                                    "type": "string"
+                                                                },
+                                                                "command_timeout": {
+                                                                    "type": "integer"
+                                                                },
+                                                                "content_set": {
+                                                                    "properties": {
+                                                                        "id": {
+                                                                            "type": "integer"
+                                                                        },
+                                                                        "name": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "type": "object"
+                                                                },
+                                                                "creation_time": {
+                                                                    "type": "string"
+                                                                },
+                                                                "deleted_flag": {
                                                                     "type": "boolean"
+                                                                },
+                                                                "display_name": {
+                                                                    "type": "string"
+                                                                },
+                                                                "expire_seconds": {
+                                                                    "type": "integer"
+                                                                },
+                                                                "hidden_flag": {
+                                                                    "type": "boolean"
+                                                                },
+                                                                "id": {
+                                                                    "type": "integer"
+                                                                },
+                                                                "last_modified_by": {
+                                                                    "type": "string"
+                                                                },
+                                                                "last_update": {
+                                                                    "type": "string"
+                                                                },
+                                                                "mod_user": {
+                                                                    "properties": {
+                                                                        "display_name": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "domain": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "id": {
+                                                                            "type": "integer"
+                                                                        },
+                                                                        "name": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "type": "object"
+                                                                },
+                                                                "modification_time": {
+                                                                    "type": "string"
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                },
+                                                                "parameter_definition": {
+                                                                    "type": "string"
+                                                                },
+                                                                "process_group_flag": {
+                                                                    "type": "boolean"
+                                                                },
+                                                                "skip_lock_flag": {
+                                                                    "type": "boolean"
+                                                                },
+                                                                "source_hash": {
+                                                                    "type": "string"
+                                                                },
+                                                                "verify_expire_seconds": {
+                                                                    "type": "integer"
+                                                                },
+                                                                "verify_group": {
+                                                                    "properties": {
+                                                                        "id": {
+                                                                            "type": "integer"
+                                                                        }
+                                                                    },
+                                                                    "type": "object"
+                                                                },
+                                                                "verify_group_id": {
+                                                                    "type": "integer"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "saved_action": {
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "integer"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "skip_lock_flag": {
+                                                            "type": "boolean"
+                                                        },
+                                                        "start_time": {
+                                                            "type": "string"
+                                                        },
+                                                        "status": {
+                                                            "type": "string"
+                                                        },
+                                                        "stopped_flag": {
+                                                            "type": "boolean"
+                                                        },
+                                                        "target_group": {
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "integer"
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "user": {
+                                                            "properties": {
+                                                                "creation_time": {
+                                                                    "type": "string"
+                                                                },
+                                                                "deleted_flag": {
+                                                                    "type": "boolean"
+                                                                },
+                                                                "display_name": {
+                                                                    "type": "string"
+                                                                },
+                                                                "domain": {
+                                                                    "type": "string"
+                                                                },
+                                                                "effective_group_id": {
+                                                                    "type": "integer"
+                                                                },
+                                                                "external_flag": {
+                                                                    "type": "integer"
+                                                                },
+                                                                "group_id": {
+                                                                    "type": "integer"
+                                                                },
+                                                                "id": {
+                                                                    "type": "integer"
+                                                                },
+                                                                "last_login": {
+                                                                    "type": "string"
+                                                                },
+                                                                "locked_out": {
+                                                                    "type": "integer"
+                                                                },
+                                                                "mod_user": {
+                                                                    "properties": {
+                                                                        "display_name": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "domain": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "id": {
+                                                                            "type": "integer"
+                                                                        },
+                                                                        "name": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "type": "object"
+                                                                },
+                                                                "modification_time": {
+                                                                    "type": "string"
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                },
+                                                                "previous_login": {
+                                                                    "type": "string"
                                                                 }
                                                             },
                                                             "type": "object"
@@ -2329,177 +2457,153 @@
                                                     "type": "object"
                                                 }
                                             },
-                                            "type": "object"
-                                        },
-                                        "errors": {
-                                            "items": {
-                                                "properties": {
-                                                    "message": {
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "message"
-                                                ],
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        }
-                                    },
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "Parse_endpoints_array": {
-                            "runAfter": {
-                                "Paginate_API_Gateway_query_if_needed": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "ParseJson",
-                            "inputs": {
-                                "content": "@variables('endpoints')",
-                                "schema": {
-                                    "type": "array"
-                                }
-                            },
-                            "description": "We need an action's output to use in the JavaScript code since it can't read from a variable"
-                        },
-                        "Query_API_Gateway": {
-                            "runAfter": {
-                                "Initialize_API_Gateway_Query_Variables": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "Http",
-                            "inputs": {
-                                "body": {
-                                    "query": "@variables('api gateway query')",
-                                    "variables": "@json(variables('api gateway query variables'))"
-                                },
-                                "headers": {
-                                    "Content-Type": "application/json",
-                                    "session": "@parameters('TaniumApiToken')"
-                                },
-                                "method": "POST",
-                                "uri": "@parameters('TaniumApiGatewayApi')"
-                            },
-                            "runtimeConfiguration": {
-                                "secureData": {
-                                    "properties": [
-                                        "inputs"
-                                    ]
-                                }
-                            }
-                        },
-                        "Select_expire_seconds": {
-                            "runAfter": {
-                                "Add_comment_to_incident_(V3)_2": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "Select",
-                            "inputs": {
-                                "from": "@variables('issued actions')",
-                                "select": "@int(item()?['expire_seconds'])"
-                            }
-                        },
-                        "Switch_to_TS_from_TDS_if_needed": {
-                            "actions": {
-                                "Requery_the_API_Gateway": {
-                                    "runAfter": {
-                                        "Update_API_Query_variables_to_get_new_source": [
-                                            "Succeeded"
-                                        ]
-                                    },
-                                    "type": "Http",
-                                    "inputs": {
-                                        "body": {
-                                            "query": "@variables('api gateway query')",
-                                            "variables": "@json(variables('api gateway query variables'))"
-                                        },
-                                        "headers": {
-                                            "Content-Type": "application/json",
-                                            "session": "@parameters('TaniumApiToken')"
-                                        },
-                                        "method": "POST",
-                                        "uri": "@parameters('TaniumApiGatewayApi')"
-
-                                    },
-                                    "runtimeConfiguration": {
-                                        "secureData": {
-                                            "properties": [
-                                                "inputs"
-                                            ]
-                                        }
-                                    }
-                                },
-                                "Set_Tanium_Endpoint_Source_to_TS": {
-                                    "runAfter": {},
-                                    "type": "SetVariable",
-                                    "inputs": {
-                                        "name": "tanium endpoint source",
-                                        "value": {
-                                            "ts": {
-                                                "stableWaitTime": 30
+                                            "runAfter": {
+                                                "Get_action_result": [
+                                                    "Succeeded"
+                                                ]
                                             }
                                         }
-                                    }
-                                },
-                                "Update_API_Gateway_Response": {
+                                    },
                                     "runAfter": {
-                                        "Requery_the_API_Gateway": [
-                                            "Succeeded"
+                                        "Wait_for_the_max_expire_seconds_from_the_issued_actions": [
+                                            "SUCCEEDED"
                                         ]
                                     },
-                                    "type": "SetVariable",
-                                    "inputs": {
-                                        "name": "API Gateway Response",
-                                        "value": "@body('Requery_the_API_Gateway')"
+                                    "runtimeConfiguration": {
+                                        "concurrency": {
+                                            "repetitions": 1
+                                        }
                                     }
                                 },
-                                "Update_API_Query_variables_to_get_new_source": {
+                                "Create_HTML_table_of_action_results": {
+                                    "type": "Table",
+                                    "inputs": {
+                                        "from": "@variables('knownActionResults')",
+                                        "format": "HTML"
+                                    },
                                     "runAfter": {
-                                        "Set_Tanium_Endpoint_Source_to_TS": [
-                                            "Succeeded"
+                                        "Collect_action_results_for_each_issued_action": [
+                                            "SUCCEEDED"
+                                        ]
+                                    }
+                                },
+                                "Create_HTML_table_of_unknown_action_results": {
+                                    "type": "Table",
+                                    "inputs": {
+                                        "from": "@variables('unknownActionResults')",
+                                        "format": "HTML"
+                                    },
+                                    "runAfter": {
+                                        "Collect_action_results_for_each_issued_action": [
+                                            "SUCCEEDED"
+                                        ]
+                                    }
+                                },
+                                "If_action_results_and_unknown_action_results": {
+                                    "type": "If",
+                                    "expression": {
+                                        "and": [
+                                            {
+                                                "greater": [
+                                                    "@length(variables('knownActionResults'))",
+                                                    0
+                                                ]
+                                            },
+                                            {
+                                                "greater": [
+                                                    "@length(variables('unknownActionResults'))",
+                                                    0
+                                                ]
+                                            }
                                         ]
                                     },
-                                    "type": "SetVariable",
-                                    "inputs": {
-                                        "name": "api gateway query variables",
-                                        "value": "{\n  \"source\": @{variables('Tanium Endpoint Source')},\n  \"incidentHosts\": {\n    \"any\": true,\n    \"filters\": @{variables('endpoint filters')}\n  }\n}"
+                                    "actions": {
+                                        "Add_comment_to_incident_-_known_and_unknown_action_results": {
+                                            "type": "ApiConnection",
+                                            "inputs": {
+                                                "host": {
+                                                    "connection": {
+                                                        "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                                    }
+                                                },
+                                                "method": "post",
+                                                "body": {
+                                                    "incidentArmId": "@triggerBody()?['object']?['id']",
+                                                    "message": "<p>QUARANTINE ACTION RESULTS<br>\n@{body('Create_HTML_table_of_action_results')}<br>\n<br>\n@{body('Create_HTML_table_of_unknown_action_results')}</p>"
+                                                },
+                                                "path": "/Incidents/Comment"
+                                            }
+                                        }
+                                    },
+                                    "else": {
+                                        "actions": {
+                                            "If_action_results": {
+                                                "type": "If",
+                                                "expression": {
+                                                    "and": [
+                                                        {
+                                                            "greater": [
+                                                                "@length(variables('knownActionResults'))",
+                                                                0
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "actions": {
+                                                    "Add_comment_to_incident_-_known_action_results": {
+                                                        "type": "ApiConnection",
+                                                        "inputs": {
+                                                            "host": {
+                                                                "connection": {
+                                                                    "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                                                }
+                                                            },
+                                                            "method": "post",
+                                                            "body": {
+                                                                "incidentArmId": "@triggerBody()?['object']?['id']",
+                                                                "message": "<p>QUARANTINE ACTION RESULTS<br>\n@{body('Create_HTML_table_of_action_results')}</p>"
+                                                            },
+                                                            "path": "/Incidents/Comment"
+                                                        }
+                                                    }
+                                                },
+                                                "else": {
+                                                    "actions": {
+                                                        "Add_comment_to_incident_-_unknown_action_results": {
+                                                            "type": "ApiConnection",
+                                                            "inputs": {
+                                                                "host": {
+                                                                    "connection": {
+                                                                        "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                                                    }
+                                                                },
+                                                                "method": "post",
+                                                                "body": {
+                                                                    "incidentArmId": "@triggerBody()?['object']?['id']",
+                                                                    "message": "<p>QUARANTINE ACTION RESULTS<br>\n@{body('Create_HTML_table_of_unknown_action_results')}</p>"
+                                                                },
+                                                                "path": "/Incidents/Comment"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "runAfter": {
+                                        "Create_HTML_table_of_unknown_action_results": [
+                                            "SUCCEEDED"
+                                        ],
+                                        "Create_HTML_table_of_action_results": [
+                                            "SUCCEEDED"
+                                        ]
                                     }
                                 }
                             },
                             "runAfter": {
-                                "Initialize_API_Gateway_Response": [
-                                    "Succeeded"
+                                "Initialize_action_results": [
+                                    "SUCCEEDED"
                                 ]
-                            },
-                            "expression": {
-                                "and": [
-                                    {
-                                        "contains": [
-                                            "@string(body('Query_API_Gateway'))",
-                                            "must refer to an existing sensor"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "If"
-                        },
-                        "Wait_for_the_max_expire_seconds_from_the_issued_actions": {
-                            "runAfter": {
-                                "Select_expire_seconds": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "Wait",
-                            "inputs": {
-                                "interval": {
-                                    "count": "@max(body('Select_expire_seconds'))",
-                                    "unit": "Second"
-                                }
                             }
                         }
                     },

--- a/Solutions/Tanium/Playbooks/Tanium-QuarantineHosts/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-QuarantineHosts/azuredeploy.json
@@ -6,13 +6,13 @@
         "description": "During an investigation, it may be critical to isolate endpoints quickly if a compromise is detected. It's also important to track quarantine actions for auditing purposes.\nThis playbook starts with a Microsoft Sentinel incident, gets the hosts associated with that incident, then directs Tanium to quarantine those hosts. The status of the quarantine operation is commented on the Microsoft Sentinel incident.\n\nSee [Tanium Help](https://help.tanium.com/bundle/ConnectAzureSentinel/page/Integrations/MSFT/ConnectAzureSentinel/Overview.htm) for a guide to setting up the Tanium Connector for Sentinel.",
         "prerequisites": [
             "1. Microsoft Sentinel incidents with associated hosts.",
-            "2. A [Tanium API Token](https://help.tanium.com/bundle/ug_console_cloud/page/platform_user/console_api_tokens.html) granting access to your Tanium environment: the query will be made with the user priviledges of that token."
+            "2. A [Tanium API Token](https://help.tanium.com/bundle/ug_console_cloud/page/platform_user/console_api_tokens.html) granting access to your Tanium environment: the query will be made with the user privileges of that token."
         ],
         "postDeploymentSteps": [
             "1. Ensure the Logic App API connection to Microsoft Sentinel is authenticated."
         ],
         "entities": [ "host" ],
-        "tags": ["Remediation"],
+        "tags": [ "Remediation" ],
         "lastUpdateTime": "2023-12-08T00:00:00.000Z",
         "support": {
             "tier": "developer",
@@ -66,17 +66,17 @@
     },
     "resources": [
         {
-          "type": "Microsoft.Web/connections",
-          "apiVersion": "2018-07-01-preview",
-          "name": "[variables('AzureSentinelConnectionName')]",
-          "location": "[resourceGroup().location]",
-          "properties": {
-              "displayName": "[variables('AzureSentinelConnectionName')]",
-              "customParameterValues": {},
-              "api": {
-                  "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/azuresentinel')]"
-              }
-          }
+            "type": "Microsoft.Web/connections",
+            "apiVersion": "2018-07-01-preview",
+            "name": "[variables('AzureSentinelConnectionName')]",
+            "location": "[resourceGroup().location]",
+            "properties": {
+                "displayName": "[variables('AzureSentinelConnectionName')]",
+                "customParameterValues": {},
+                "api": {
+                    "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/azuresentinel')]"
+                }
+            }
         },
         {
             "type": "Microsoft.Logic/workflows",
@@ -88,7 +88,7 @@
                 "hidden-SentinelTemplateVersion": "2.0"
             },
             "dependsOn": [
-              "[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]"
+                "[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]"
             ],
             "properties": {
                 "state": "Enabled",

--- a/Solutions/Tanium/Playbooks/Tanium-QuarantineHosts/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-QuarantineHosts/azuredeploy.json
@@ -224,7 +224,7 @@
                                             },
                                             "host": {
                                                 "connection": {
-                                                    "name": "@parameters('$connections')['azuresentinel-1']['connectionId']"
+                                                    "name": "@parameters('$connections')['azuresentinel']['connectionId']"
                                                 }
                                             },
                                             "method": "post",
@@ -1239,7 +1239,7 @@
                                 "variables": [
                                     {
                                         "name": "allComputersGroupId",
-                                        "type": "string"
+                                        "type": "integer"
                                     }
                                 ]
                             }

--- a/Solutions/Tanium/Playbooks/Tanium-QuarantineHosts/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-QuarantineHosts/azuredeploy.json
@@ -13,7 +13,7 @@
         ],
         "entities": [ "host" ],
         "tags": [ "Remediation" ],
-        "lastUpdateTime": "2023-12-08T00:00:00.000Z",
+        "lastUpdateTime": "2025-06-27T00:00:00.000Z",
         "support": {
             "tier": "developer",
             "link": "https://www.tanium.com"
@@ -95,7 +95,7 @@
             },
             "tags": {
                 "hidden-SentinelTemplateName": "Tanium-QuarantineHosts",
-                "hidden-SentinelTemplateVersion": "2.0"
+                "hidden-SentinelTemplateVersion": "2.1"
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/connections', parameters('AzureSentinelConnectionName'))]"

--- a/azure-arm-template-words.txt
+++ b/azure-arm-template-words.txt
@@ -1,0 +1,2 @@
+azuresentinel
+securestring


### PR DESCRIPTION
Updated the Quarantine Hosts playbook.

# Change Summary

## Reorganized

Reorganized and updated names of actions within the playbook to make it far more readable and easier to view/understand when in the GUI editor in Azure Portal.

## Updated Sentinel Connection

The API Connection that was created to allow the playbook to connect to Azure Sentinel (and interact, like leaving comments or using incident triggers) was having to be manually authorized and therefore also impersonating the user who authorized it.

Updated the ARM template to use managed identity for the logic app itself and then use that for the connection, so that when the playbook is created it is already authorized.