### PR TITLE
feat(playbooks: unquarantine) Add managed identity and refresh playbook

### DIFF
--- a/Solutions/Tanium/Playbooks/Tanium-UnquarantineHosts/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-UnquarantineHosts/azuredeploy.json
@@ -1197,7 +1197,7 @@
                                     {
                                         "name": "linuxPackageName",
                                         "type": "string",
-                                        "value": "Remove Linux IPTables Quarantine"
+                                        "value": "Threat Response - Unquarantine Endpoint [Linux]"
                                     }
                                 ]
                             }
@@ -1214,7 +1214,7 @@
                                     {
                                         "name": "macOsPackageName",
                                         "type": "string",
-                                        "value": "Remove Mac PF Quarantine"
+                                        "value": "Threat Response - Unquarantine Endpoint [Mac]"
                                     }
                                 ]
                             }
@@ -1250,7 +1250,7 @@
                                     {
                                         "name": "windowsPackageName",
                                         "type": "string",
-                                        "value": "Remove Windows IPsec Quarantine"
+                                        "value": "Threat Response - Unquarantine Endpoint [Windows]"
                                     }
                                 ]
                             }
@@ -1581,7 +1581,10 @@
                                                                 "pageInfo": {
                                                                     "properties": {
                                                                         "endCursor": {
-                                                                            "type": "string"
+                                                                            "type": [
+                                                                                "string",
+                                                                                "null"
+                                                                            ]
                                                                         },
                                                                         "hasNextPage": {
                                                                             "type": "boolean"

--- a/Solutions/Tanium/Playbooks/Tanium-UnquarantineHosts/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-UnquarantineHosts/azuredeploy.json
@@ -1773,7 +1773,7 @@
                         },
                         "Initialize_API_Variables": {
                             "runAfter": {
-                                "Initialize_Tanium_Endpoint_Source_to_TDS": [
+                                "Initialize_Endpoint_Source_to_TDS": [
                                     "Succeeded"
                                 ]
                             },
@@ -1938,7 +1938,7 @@
                                 ]
                             }
                         },
-                        "Initialize_Tanium_Endpoint_Source_to_TDS": {
+                        "Initialize_Endpoint_Source_to_TDS": {
                             "runAfter": {
                                 "Set_Endpoint_Filter": [
                                     "Succeeded"

--- a/Solutions/Tanium/Playbooks/Tanium-UnquarantineHosts/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-UnquarantineHosts/azuredeploy.json
@@ -142,27 +142,6 @@
                         }
                     },
                     "actions": {
-                        "Add_Issued_Actions_to_Incident": {
-                            "runAfter": {
-                                "Create_HTML_table_of_issued_actions": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "ApiConnection",
-                            "inputs": {
-                                "body": {
-                                    "incidentArmId": "@triggerBody()?['object']?['id']",
-                                    "message": "<p>ISSUED TANIUM ACTIONS<br>\n@{body('Create_HTML_table_of_issued_actions')}</p>"
-                                },
-                                "host": {
-                                    "connection": {
-                                        "name": "@parameters('$connections')['azuresentinel']['connectionId']"
-                                    }
-                                },
-                                "method": "post",
-                                "path": "/Incidents/Comment"
-                            }
-                        },
                         "Add_comment_to_incident_-_hosts_that_will_be_targeted": {
                             "runAfter": {
                                 "Create_HTML_table_of_matched_endpoints": [
@@ -199,6 +178,12 @@
                             "runAfter": {
                                 "Apply_unquarantine_action_to_Linux_endpoints": [
                                     "Succeeded"
+                                ],
+                                "Apply_unquarantine_action_to_Windows_endpoints": [
+                                    "Succeeded"
+                                ],
+                                "Apply_unquarantine_action_to_macOS_endpoints": [
+                                    "Succeeded"
                                 ]
                             },
                             "expression": {
@@ -213,7 +198,50 @@
                             },
                             "type": "If",
                             "else": {
-                                "actions": {}
+                                "actions": {
+                                    "Create_HTML_table_of_issued_actions": {
+                                        "type": "Table",
+                                        "inputs": {
+                                            "from": "@variables('issuedActions')",
+                                            "format": "HTML",
+                                            "columns": [
+                                                {
+                                                    "header": "action id",
+                                                    "value": "@item()?['id']"
+                                                },
+                                                {
+                                                    "header": "name",
+                                                    "value": "@item()?['name']"
+                                                },
+                                                {
+                                                    "header": "status",
+                                                    "value": "@item()?['status']"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "Add_Issued_Actions_to_Incident": {
+                                        "type": "ApiConnection",
+                                        "inputs": {
+                                            "host": {
+                                                "connection": {
+                                                    "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                                }
+                                            },
+                                            "method": "post",
+                                            "body": {
+                                                "incidentArmId": "@triggerBody()?['object']?['id']",
+                                                "message": "<p class=\"editor-paragraph\">ISSUED TANIUM ACTIONS</p><p class=\"editor-paragraph\">@{body('Create_HTML_table_of_issued_actions')}</p>"
+                                            },
+                                            "path": "/Incidents/Comment"
+                                        },
+                                        "runAfter": {
+                                            "Create_HTML_table_of_issued_actions": [
+                                                "SUCCEEDED"
+                                            ]
+                                        }
+                                    }
+                                }
                             }
                         },
                         "Collect_action_results_for_each_issued_action": {
@@ -563,7 +591,7 @@
                                 }
                             },
                             "runAfter": {
-                                "Initialize_action_results": [
+                                "Wait_for_the_max_expire_seconds_from_the_issued_actions": [
                                     "Succeeded"
                                 ]
                             },
@@ -586,32 +614,6 @@
                                 "from": "@variables('knownActionResults')"
                             }
                         },
-                        "Create_HTML_table_of_issued_actions": {
-                            "runAfter": {
-                                "Exit_early_if_no_unquarantine_actions_were_successfully_issued": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "Table",
-                            "inputs": {
-                                "columns": [
-                                    {
-                                        "header": "action id",
-                                        "value": "@item()?['id']"
-                                    },
-                                    {
-                                        "header": "name",
-                                        "value": "@item()?['name']"
-                                    },
-                                    {
-                                        "header": "status",
-                                        "value": "@item()?['status']"
-                                    }
-                                ],
-                                "format": "HTML",
-                                "from": "@variables('issuedActions')"
-                            }
-                        },
                         "Create_HTML_table_of_matched_endpoints": {
                             "runAfter": {
                                 "Flatten_API_Gateway_endpoints": [
@@ -626,8 +628,8 @@
                         },
                         "Create_HTML_table_of_unknown_action_results": {
                             "runAfter": {
-                                "Create_HTML_table_of_action_results": [
-                                    "Succeeded"
+                                "Collect_action_results_for_each_issued_action": [
+                                    "SUCCEEDED"
                                 ]
                             },
                             "type": "Table",
@@ -702,13 +704,13 @@
                         },
                         "Flatten_API_Gateway_endpoints": {
                             "runAfter": {
-                                "Parse_the_array_endpoints": [
+                                "Parse_endpoints_array": [
                                     "Succeeded"
                                 ]
                             },
                             "type": "JavaScriptCode",
                             "inputs": {
-                                "code": "var e = workflowContext.actions.Parse_the_array_endpoints.outputs.body;\r\n\r\nfunction sensorReadings(r) {\r\n\treturn r.columns.map(c => {\r\n\t\tif (c.sensor && c.sensor.name) {\r\n\t\t\treturn { name: [c.sensor.name, c.name].join(' - '), value: c.values.join(' ') };\r\n\t\t} else {\r\n\t\t\treturn { name: c.name, value: c.values.join(' ') };\r\n\t\t}\r\n\t});\r\n}\r\n\r\nfunction flatten(obj, pk = '') {\r\n\tif (pk !== '') pk += ' ';\r\n\tlet flat = {};\r\n\tObject.keys(obj).forEach((key) => {\r\n\t\tif (key === 'sensorReadings') {\r\n\t\t\tsensorReadings(obj[key]).forEach((r) => {\r\n\t\t\t\tflat[r.name] = r.value;\r\n\t\t\t});\r\n\t\t} else {\r\n\t\t\tif (typeof obj[key] === 'object' && obj[key] !== null) {\r\n\t\t\t\tObject.assign(flat, flatten(obj[key], pk + key));\r\n\t\t\t} else {\r\n\t\t\t\tflat[pk + key] = obj[key];\r\n\t\t\t}\r\n\t\t}\r\n\t});\r\n\treturn flat;\r\n}\r\n\r\nreturn e.map(function(e) { return flatten(e.node); });"
+                                "code": "var e = workflowContext.actions.Parse_endpoints_array.outputs.body;\r\n\r\nfunction sensorReadings(r) {\r\n\treturn r.columns.map(c => {\r\n\t\tif (c.sensor && c.sensor.name) {\r\n\t\t\treturn { name: [c.sensor.name, c.name].join(' - '), value: c.values.join(' ') };\r\n\t\t} else {\r\n\t\t\treturn { name: c.name, value: c.values.join(' ') };\r\n\t\t}\r\n\t});\r\n}\r\n\r\nfunction flatten(obj, pk = '') {\r\n\tif (pk !== '') pk += ' ';\r\n\tlet flat = {};\r\n\tObject.keys(obj).forEach((key) => {\r\n\t\tif (key === 'sensorReadings') {\r\n\t\t\tsensorReadings(obj[key]).forEach((r) => {\r\n\t\t\t\tflat[r.name] = r.value;\r\n\t\t\t});\r\n\t\t} else {\r\n\t\t\tif (typeof obj[key] === 'object' && obj[key] !== null) {\r\n\t\t\t\tObject.assign(flat, flatten(obj[key], pk + key));\r\n\t\t\t} else {\r\n\t\t\t\tflat[pk + key] = obj[key];\r\n\t\t\t}\r\n\t\t}\r\n\t});\r\n\treturn flat;\r\n}\r\n\r\nreturn e.map(function(e) { return flatten(e.node); });"
                             }
                         },
                         "For_each_host_on_the_incident": {
@@ -740,7 +742,7 @@
                                             }
                                         ]
                                     },
-                                    "description": "Compose the filter for the current incident host to be used to get the quarantine package"
+                                    "description": "Compose the filter for the current incident host to be used to get the unquarantine package"
                                 },
                                 "Parse_endpoint_JSON_data": {
                                     "type": "ParseJson",
@@ -824,7 +826,7 @@
                                 }
                             },
                             "runAfter": {
-                                "Initialize_allComputersGroupId": [
+                                "Set_allComputersGroupId": [
                                     "Succeeded"
                                 ]
                             },
@@ -857,6 +859,24 @@
                         "Get_the_\"All_Computers\"_group": {
                             "runAfter": {
                                 "Initialize_list_of_unknown_action_results": [
+                                    "Succeeded"
+                                ],
+                                "Initialize_list_of_issued_actions": [
+                                    "Succeeded"
+                                ],
+                                "Initialize_allComputersGroupId": [
+                                    "Succeeded"
+                                ],
+                                "Initialize_unquarantine_package_parameters": [
+                                    "Succeeded"
+                                ],
+                                "Initialize_the_filter_for_macOS_endpoint(s)": [
+                                    "Succeeded"
+                                ],
+                                "Initialize_the_filter_for_Windows_endpoint(s)": [
+                                    "Succeeded"
+                                ],
+                                "Initialize_the_filter_for_Linux_endpoint(s)": [
                                     "Succeeded"
                                 ]
                             },
@@ -1113,7 +1133,7 @@
                                 }
                             },
                             "runAfter": {
-                                "Apply_unquarantine_action_to_macOS_endpoints": [
+                                "For_each_host_on_the_incident": [
                                     "Succeeded"
                                 ]
                             },
@@ -1387,62 +1407,6 @@
                                 "actions": {}
                             }
                         },
-                        "If_action_results": {
-                            "actions": {
-                                "Add_comment_to_incident_-_known_action_results": {
-                                    "type": "ApiConnection",
-                                    "inputs": {
-                                        "body": {
-                                            "incidentArmId": "@triggerBody()?['object']?['id']",
-                                            "message": "<p>QUARANTINE ACTION RESULTS<br>\n@{body('Create_HTML_table_of_action_results')}</p>"
-                                        },
-                                        "host": {
-                                            "connection": {
-                                                "name": "@parameters('$connections')['azuresentinel']['connectionId']"
-                                            }
-                                        },
-                                        "method": "post",
-                                        "path": "/Incidents/Comment"
-                                    }
-                                }
-                            },
-                            "runAfter": {
-                                "If_action_results_and_unknown_action_results": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "else": {
-                                "actions": {
-                                    "Add_comment_to_incident_-_unknown_action_results": {
-                                        "type": "ApiConnection",
-                                        "inputs": {
-                                            "body": {
-                                                "incidentArmId": "@triggerBody()?['object']?['id']",
-                                                "message": "<p>QUARANTINE ACTION RESULTS<br>\n@{body('Create_HTML_table_of_unknown_action_results')}</p>"
-                                            },
-                                            "host": {
-                                                "connection": {
-                                                    "name": "@parameters('$connections')['azuresentinel']['connectionId']"
-                                                }
-                                            },
-                                            "method": "post",
-                                            "path": "/Incidents/Comment"
-                                        }
-                                    }
-                                }
-                            },
-                            "expression": {
-                                "and": [
-                                    {
-                                        "greater": [
-                                            "@length(variables('knownActionResults'))",
-                                            0
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "If"
-                        },
                         "If_action_results_and_unknown_action_results": {
                             "actions": {
                                 "Add_comment_to_incident_-_known_and_unknown_action_results": {
@@ -1460,23 +1424,70 @@
                                         "method": "post",
                                         "path": "/Incidents/Comment"
                                     }
-                                },
-                                "Terminate_2": {
-                                    "runAfter": {
-                                        "Add_comment_to_incident_-_known_and_unknown_action_results": [
-                                            "Succeeded"
-                                        ]
-                                    },
-                                    "type": "Terminate",
-                                    "inputs": {
-                                        "runStatus": "Succeeded"
-                                    }
                                 }
                             },
                             "runAfter": {
                                 "Create_HTML_table_of_unknown_action_results": [
                                     "Succeeded"
+                                ],
+                                "Create_HTML_table_of_action_results": [
+                                    "SUCCEEDED"
                                 ]
+                            },
+                            "else": {
+                                "actions": {
+                                    "If_action_results": {
+                                        "actions": {
+                                            "Add_comment_to_incident_-_known_action_results": {
+                                                "type": "ApiConnection",
+                                                "inputs": {
+                                                    "body": {
+                                                        "incidentArmId": "@triggerBody()?['object']?['id']",
+                                                        "message": "<p>QUARANTINE ACTION RESULTS<br>\n@{body('Create_HTML_table_of_action_results')}</p>"
+                                                    },
+                                                    "host": {
+                                                        "connection": {
+                                                            "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                                        }
+                                                    },
+                                                    "method": "post",
+                                                    "path": "/Incidents/Comment"
+                                                }
+                                            }
+                                        },
+                                        "expression": {
+                                            "and": [
+                                                {
+                                                    "greater": [
+                                                        "@length(variables('knownActionResults'))",
+                                                        0
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "type": "If",
+                                        "else": {
+                                            "actions": {
+                                                "Add_comment_to_incident_-_unknown_action_results": {
+                                                    "type": "ApiConnection",
+                                                    "inputs": {
+                                                        "body": {
+                                                            "incidentArmId": "@triggerBody()?['object']?['id']",
+                                                            "message": "<p>QUARANTINE ACTION RESULTS<br>\n@{body('Create_HTML_table_of_unknown_action_results')}</p>"
+                                                        },
+                                                        "host": {
+                                                            "connection": {
+                                                                "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                                            }
+                                                        },
+                                                        "method": "post",
+                                                        "path": "/Incidents/Comment"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
                             },
                             "expression": {
                                 "and": [
@@ -1494,10 +1505,7 @@
                                     }
                                 ]
                             },
-                            "type": "If",
-                            "else": {
-                                "actions": {}
-                            }
+                            "type": "If"
                         },
                         "Apply_unquarantine_action_to_macOS_endpoints": {
                             "actions": {
@@ -1735,7 +1743,7 @@
                                 }
                             },
                             "runAfter": {
-                                "Apply_unquarantine_action_to_Windows_endpoints": [
+                                "For_each_host_on_the_incident": [
                                     "Succeeded"
                                 ]
                             },
@@ -1756,7 +1764,7 @@
                         },
                         "Initialize_API_Query": {
                             "runAfter": {
-                                "Initialize_unquarantine_package_parameters": [
+                                "Exit_early_if_incident_has_no_hosts": [
                                     "Succeeded"
                                 ]
                             },
@@ -1775,6 +1783,9 @@
                             "runAfter": {
                                 "Initialize_Endpoint_Source_to_TDS": [
                                     "Succeeded"
+                                ],
+                                "Set_Endpoint_Filter": [
+                                    "Succeeded"
                                 ]
                             },
                             "type": "InitializeVariable",
@@ -1790,7 +1801,7 @@
                         },
                         "Initialize_API_Response": {
                             "runAfter": {
-                                "Get_General_Host_Info": [
+                                "Exit_early_if_incident_has_no_hosts": [
                                     "Succeeded"
                                 ]
                             },
@@ -1799,8 +1810,7 @@
                                 "variables": [
                                     {
                                         "name": "apiResponse",
-                                        "type": "object",
-                                        "value": "@body('Get_General_Host_Info')"
+                                        "type": "object"
                                     }
                                 ]
                             }
@@ -1855,26 +1865,9 @@
                                 "actions": {}
                             }
                         },
-                        "Initialize_cursor": {
-                            "runAfter": {
-                                "Exit_early_If_Tanium_Has_No_Data_for_Incident": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "InitializeVariable",
-                            "inputs": {
-                                "variables": [
-                                    {
-                                        "name": "cursor",
-                                        "type": "string",
-                                        "value": "@body('Parse_API_response')?['data']?['endpoints']?['pageInfo']?['endCursor']"
-                                    }
-                                ]
-                            }
-                        },
                         "Initialize_Endpoint_Filter": {
                             "runAfter": {
-                                "Initialize_API_Query": [
+                                "Exit_early_if_incident_has_no_hosts": [
                                     "Succeeded"
                                 ]
                             },
@@ -1888,25 +1881,9 @@
                                 ]
                             }
                         },
-                        "Initialize_the_filter_for_Linux_endpoint(s)": {
-                            "runAfter": {
-                                "Initialize_the_filter_for_Windows_endpoint(s)": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "InitializeVariable",
-                            "inputs": {
-                                "variables": [
-                                    {
-                                        "name": "linuxEndpointFilters",
-                                        "type": "array"
-                                    }
-                                ]
-                            }
-                        },
                         "Initialize_the_name_of_the_Linux_unquarantine_package": {
                             "runAfter": {
-                                "Initialize_the_name_of_the_MacOS_unquarantine_package": [
+                                "Add_comment_to_incident_-_hosts_that_will_be_targeted": [
                                     "Succeeded"
                                 ]
                             },
@@ -1923,7 +1900,7 @@
                         },
                         "Initialize_the_name_of_the_MacOS_unquarantine_package": {
                             "runAfter": {
-                                "Initialize_the_name_of_the_Windows_unquarantine_package": [
+                                "Add_comment_to_incident_-_hosts_that_will_be_targeted": [
                                     "Succeeded"
                                 ]
                             },
@@ -1940,7 +1917,7 @@
                         },
                         "Initialize_Endpoint_Source_to_TDS": {
                             "runAfter": {
-                                "Set_Endpoint_Filter": [
+                                "Exit_early_if_incident_has_no_hosts": [
                                     "Succeeded"
                                 ]
                             },
@@ -1957,25 +1934,9 @@
                                 ]
                             }
                         },
-                        "Initialize_the_filter_for_Windows_endpoint(s)": {
-                            "runAfter": {
-                                "Add_comment_to_incident_-_hosts_that_will_be_targeted": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "InitializeVariable",
-                            "inputs": {
-                                "variables": [
-                                    {
-                                        "name": "windowsEndpointFilters",
-                                        "type": "array"
-                                    }
-                                ]
-                            }
-                        },
                         "Initialize_the_name_of_the_Windows_unquarantine_package": {
                             "runAfter": {
-                                "Exit_early_if_incident_has_no_hosts": [
+                                "Add_comment_to_incident_-_hosts_that_will_be_targeted": [
                                     "Succeeded"
                                 ]
                             },
@@ -1990,59 +1951,9 @@
                                 ]
                             }
                         },
-                        "Initialize_action_results": {
-                            "runAfter": {
-                                "Wait_for_the_max_expire_seconds_from_the_issued_actions": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "InitializeVariable",
-                            "inputs": {
-                                "variables": [
-                                    {
-                                        "name": "knownActionResults",
-                                        "type": "array"
-                                    }
-                                ]
-                            }
-                        },
-                        "Initialize_allComputersGroupId": {
-                            "runAfter": {
-                                "Get_the_\"All_Computers\"_group": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "InitializeVariable",
-                            "inputs": {
-                                "variables": [
-                                    {
-                                        "name": "allComputersGroupId",
-                                        "type": "string",
-                                        "value": "@{body('Get_the_\"All_Computers\"_group')?['data']?['id']}"
-                                    }
-                                ]
-                            }
-                        },
-                        "Initialize_endpoints_array": {
-                            "runAfter": {
-                                "Initialize_cursor": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "InitializeVariable",
-                            "inputs": {
-                                "variables": [
-                                    {
-                                        "name": "endpoints",
-                                        "type": "array",
-                                        "value": "@body('Parse_API_response')?['data']?['endpoints']?['edges']"
-                                    }
-                                ]
-                            }
-                        },
                         "Initialize_list_of_issued_actions": {
                             "runAfter": {
-                                "Initialize_the_filter_for_macOS_endpoint(s)": [
+                                "Add_comment_to_incident_-_hosts_that_will_be_targeted": [
                                     "Succeeded"
                                 ]
                             },
@@ -2056,25 +1967,9 @@
                                 ]
                             }
                         },
-                        "Initialize_the_filter_for_macOS_endpoint(s)": {
-                            "runAfter": {
-                                "Initialize_the_filter_for_Linux_endpoint(s)": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "InitializeVariable",
-                            "inputs": {
-                                "variables": [
-                                    {
-                                        "name": "macOsEndpointFilters",
-                                        "type": "array"
-                                    }
-                                ]
-                            }
-                        },
                         "Initialize_unquarantine_package_parameters": {
                             "runAfter": {
-                                "Initialize_the_name_of_the_Linux_unquarantine_package": [
+                                "Add_comment_to_incident_-_hosts_that_will_be_targeted": [
                                     "Succeeded"
                                 ]
                             },
@@ -2091,7 +1986,7 @@
                         },
                         "Initialize_list_of_unknown_action_results": {
                             "runAfter": {
-                                "Initialize_list_of_issued_actions": [
+                                "Add_comment_to_incident_-_hosts_that_will_be_targeted": [
                                     "Succeeded"
                                 ]
                             },
@@ -2242,7 +2137,10 @@
                                 }
                             },
                             "runAfter": {
-                                "Initialize_endpoints_array": [
+                                "Set_cursor": [
+                                    "Succeeded"
+                                ],
+                                "Set_endpoints_list": [
                                     "Succeeded"
                                 ]
                             },
@@ -2327,7 +2225,7 @@
                                 }
                             }
                         },
-                        "Parse_the_array_endpoints": {
+                        "Parse_endpoints_array": {
                             "runAfter": {
                                 "Loop_Paginated_Response_if_has_multiple_pages": [
                                     "Succeeded"
@@ -2345,6 +2243,15 @@
                         "Get_General_Host_Info": {
                             "runAfter": {
                                 "Initialize_API_Variables": [
+                                    "Succeeded"
+                                ],
+                                "Initialize_API_Query": [
+                                    "Succeeded"
+                                ],
+                                "Initialize_cursor": [
+                                    "Succeeded"
+                                ],
+                                "Initialize_endpoints_array": [
                                     "Succeeded"
                                 ]
                             },
@@ -2372,8 +2279,8 @@
                         },
                         "Select_expire_seconds": {
                             "runAfter": {
-                                "Add_Issued_Actions_to_Incident": [
-                                    "Succeeded"
+                                "Initialize_action_results": [
+                                    "SUCCEEDED"
                                 ]
                             },
                             "type": "Select",
@@ -2448,7 +2355,7 @@
                                 }
                             },
                             "runAfter": {
-                                "Initialize_API_Response": [
+                                "Set_apiResponse": [
                                     "Succeeded"
                                 ]
                             },
@@ -2480,6 +2387,166 @@
                                     "count": "@max(body('Select_expire_seconds'))",
                                     "unit": "Second"
                                 }
+                            }
+                        },
+                        "Initialize_cursor": {
+                            "type": "InitializeVariable",
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "cursor",
+                                        "type": "string"
+                                    }
+                                ]
+                            },
+                            "runAfter": {
+                                "Initialize_API_Response": [
+                                    "Succeeded"
+                                ]
+                            }
+                        },
+                        "Initialize_endpoints_array": {
+                            "type": "InitializeVariable",
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "endpoints",
+                                        "type": "array"
+                                    }
+                                ]
+                            },
+                            "runAfter": {
+                                "Exit_early_if_incident_has_no_hosts": [
+                                    "Succeeded"
+                                ]
+                            }
+                        },
+                        "Set_apiResponse": {
+                            "type": "SetVariable",
+                            "inputs": {
+                                "name": "apiResponse",
+                                "value": "@body('Get_General_Host_Info')"
+                            },
+                            "runAfter": {
+                                "Get_General_Host_Info": [
+                                    "Succeeded"
+                                ]
+                            }
+                        },
+                        "Set_cursor": {
+                            "type": "SetVariable",
+                            "inputs": {
+                                "name": "cursor",
+                                "value": "@body('Parse_API_response')?['data']?['endpoints']?['pageInfo']?['endCursor']"
+                            },
+                            "runAfter": {
+                                "Exit_early_If_Tanium_Has_No_Data_for_Incident": [
+                                    "Succeeded"
+                                ]
+                            }
+                        },
+                        "Set_endpoints_list": {
+                            "type": "SetVariable",
+                            "inputs": {
+                                "name": "endpoints",
+                                "value": "@body('Parse_API_response')?['data']?['endpoints']?['edges']"
+                            },
+                            "runAfter": {
+                                "Exit_early_If_Tanium_Has_No_Data_for_Incident": [
+                                    "Succeeded"
+                                ]
+                            }
+                        },
+                        "Initialize_allComputersGroupId": {
+                            "type": "InitializeVariable",
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "allComputersGroupId",
+                                        "type": "string"
+                                    }
+                                ]
+                            },
+                            "runAfter": {
+                                "Add_comment_to_incident_-_hosts_that_will_be_targeted": [
+                                    "Succeeded"
+                                ]
+                            }
+                        },
+                        "Initialize_the_filter_for_Windows_endpoint(s)": {
+                            "type": "InitializeVariable",
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "windowsEndpointFilters",
+                                        "type": "array"
+                                    }
+                                ]
+                            },
+                            "runAfter": {
+                                "Initialize_the_name_of_the_Windows_unquarantine_package": [
+                                    "Succeeded"
+                                ]
+                            }
+                        },
+                        "Initialize_the_filter_for_Linux_endpoint(s)": {
+                            "type": "InitializeVariable",
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "linuxEndpointFilters",
+                                        "type": "array"
+                                    }
+                                ]
+                            },
+                            "runAfter": {
+                                "Initialize_the_name_of_the_Linux_unquarantine_package": [
+                                    "Succeeded"
+                                ]
+                            }
+                        },
+                        "Initialize_the_filter_for_macOS_endpoint(s)": {
+                            "type": "InitializeVariable",
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "macOsEndpointFilters",
+                                        "type": "array"
+                                    }
+                                ]
+                            },
+                            "runAfter": {
+                                "Initialize_the_name_of_the_MacOS_unquarantine_package": [
+                                    "Succeeded"
+                                ]
+                            }
+                        },
+                        "Set_allComputersGroupId": {
+                            "type": "SetVariable",
+                            "inputs": {
+                                "name": "allComputersGroupId",
+                                "value": "@body('Get_the_\"All_Computers\"_group')?['data']?['id']"
+                            },
+                            "runAfter": {
+                                "Get_the_\"All_Computers\"_group": [
+                                    "Succeeded"
+                                ]
+                            }
+                        },
+                        "Initialize_action_results": {
+                            "type": "InitializeVariable",
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "knownActionResults",
+                                        "type": "array"
+                                    }
+                                ]
+                            },
+                            "runAfter": {
+                                "Exit_early_if_no_unquarantine_actions_were_successfully_issued": [
+                                    "Succeeded"
+                                ]
                             }
                         }
                     },

--- a/Solutions/Tanium/Playbooks/Tanium-UnquarantineHosts/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-UnquarantineHosts/azuredeploy.json
@@ -142,7 +142,7 @@
                         }
                     },
                     "actions": {
-                        "Add_comment_to_incident_(V3)_2": {
+                        "Add_Issued_Actions_to_Incident": {
                             "runAfter": {
                                 "Create_HTML_table_of_issued_actions": [
                                     "Succeeded"
@@ -184,10 +184,9 @@
                                 "path": "/Incidents/Comment"
                             }
                         },
-                        "Check_issued_actions": {
+                        "Exit_early_if_no_unquarantine_actions_were_successfully_issued": {
                             "actions": {
                                 "Terminate_-_no_actions_were_successfully_issued": {
-                                    "runAfter": {},
                                     "type": "Terminate",
                                     "inputs": {
                                         "runError": {
@@ -198,7 +197,7 @@
                                 }
                             },
                             "runAfter": {
-                                "If_Linux_endpoints": [
+                                "Apply_unquarantine_action_to_Linux_endpoints": [
                                     "Succeeded"
                                 ]
                             },
@@ -212,13 +211,15 @@
                                     }
                                 ]
                             },
-                            "type": "If"
+                            "type": "If",
+                            "else": {
+                                "actions": {}
+                            }
                         },
                         "Collect_action_results_for_each_issued_action": {
                             "foreach": "@variables('issuedActions')",
                             "actions": {
                                 "Get_action_result": {
-                                    "runAfter": {},
                                     "type": "Http",
                                     "inputs": {
                                         "headers": {
@@ -242,7 +243,6 @@
                                             "foreach": "@body('Parse_action_result')",
                                             "actions": {
                                                 "Append_to_action_results": {
-                                                    "runAfter": {},
                                                     "type": "AppendToArrayVariable",
                                                     "inputs": {
                                                         "name": "knownActionResults",
@@ -250,7 +250,6 @@
                                                     }
                                                 }
                                             },
-                                            "runAfter": {},
                                             "type": "Foreach"
                                         }
                                     },
@@ -274,7 +273,6 @@
                                                 }
                                             },
                                             "Compose_unknown_action_result": {
-                                                "runAfter": {},
                                                 "type": "Compose",
                                                 "inputs": {
                                                     "action id": "@item()?['id']",
@@ -590,7 +588,7 @@
                         },
                         "Create_HTML_table_of_issued_actions": {
                             "runAfter": {
-                                "Check_issued_actions": [
+                                "Exit_early_if_no_unquarantine_actions_were_successfully_issued": [
                                     "Succeeded"
                                 ]
                             },
@@ -652,10 +650,9 @@
                                 "path": "/entities/host"
                             }
                         },
-                        "Exit_early_if_no_hosts_are_found": {
+                        "Exit_early_if_incident_has_no_hosts": {
                             "actions": {
-                                "Add_comment_to_incident_(V3)": {
-                                    "runAfter": {},
+                                "Add_comment__-_no_hosts_found": {
                                     "type": "ApiConnection",
                                     "inputs": {
                                         "body": {
@@ -671,9 +668,9 @@
                                         "path": "/Incidents/Comment"
                                     }
                                 },
-                                "Terminate": {
+                                "Exit_early": {
                                     "runAfter": {
-                                        "Add_comment_to_incident_(V3)": [
+                                        "Add_comment__-_no_hosts_found": [
                                             "Succeeded"
                                         ]
                                     },
@@ -698,7 +695,10 @@
                                     }
                                 ]
                             },
-                            "type": "If"
+                            "type": "If",
+                            "else": {
+                                "actions": {}
+                            }
                         },
                         "Flatten_API_Gateway_endpoints": {
                             "runAfter": {
@@ -711,7 +711,7 @@
                                 "code": "var e = workflowContext.actions.Parse_endpoints_array.outputs.body;\r\n\r\nfunction sensorReadings(r) {\r\n\treturn r.columns.map(c => {\r\n\t\tif (c.sensor && c.sensor.name) {\r\n\t\t\treturn { name: [c.sensor.name, c.name].join(' - '), value: c.values.join(' ') };\r\n\t\t} else {\r\n\t\t\treturn { name: c.name, value: c.values.join(' ') };\r\n\t\t}\r\n\t});\r\n}\r\n\r\nfunction flatten(obj, pk = '') {\r\n\tif (pk !== '') pk += ' ';\r\n\tlet flat = {};\r\n\tObject.keys(obj).forEach((key) => {\r\n\t\tif (key === 'sensorReadings') {\r\n\t\t\tsensorReadings(obj[key]).forEach((r) => {\r\n\t\t\t\tflat[r.name] = r.value;\r\n\t\t\t});\r\n\t\t} else {\r\n\t\t\tif (typeof obj[key] === 'object' && obj[key] !== null) {\r\n\t\t\t\tObject.assign(flat, flatten(obj[key], pk + key));\r\n\t\t\t} else {\r\n\t\t\t\tflat[pk + key] = obj[key];\r\n\t\t\t}\r\n\t\t}\r\n\t});\r\n\treturn flat;\r\n}\r\n\r\nreturn e.map(function(e) { return flatten(e.node); });"
                             }
                         },
-                        "For_each_endpoint": {
+                        "For_each_host_on_the_incident": {
                             "foreach": "@variables('endpoints')",
                             "actions": {
                                 "Compose_endpoint_filter_for_packages": {
@@ -742,10 +742,9 @@
                                     }
                                 },
                                 "Parse_endpoint_JSON_data": {
-                                    "runAfter": {},
                                     "type": "ParseJson",
                                     "inputs": {
-                                        "content": "@items('For_each_endpoint')",
+                                        "content": "@items('For_each_host_on_the_incident')",
                                         "schema": {
                                             "properties": {
                                                 "node": {
@@ -783,7 +782,6 @@
                                             "case": "Linux",
                                             "actions": {
                                                 "Append_to_Linux_endpoint_filters": {
-                                                    "runAfter": {},
                                                     "type": "AppendToArrayVariable",
                                                     "inputs": {
                                                         "name": "linuxEndpointFilters",
@@ -796,7 +794,6 @@
                                             "case": "Mac",
                                             "actions": {
                                                 "Append_to_macOS_endpoint_filters": {
-                                                    "runAfter": {},
                                                     "type": "AppendToArrayVariable",
                                                     "inputs": {
                                                         "name": "macOsEndpointFilters",
@@ -809,7 +806,6 @@
                                             "case": "Windows",
                                             "actions": {
                                                 "Append_to_Windows_endpoint_filters": {
-                                                    "runAfter": {},
                                                     "type": "AppendToArrayVariable",
                                                     "inputs": {
                                                         "name": "windowsEndpointFilters",
@@ -827,7 +823,7 @@
                                 }
                             },
                             "runAfter": {
-                                "Initialize_all_computers_id": [
+                                "Initialize_allComputersGroupId": [
                                     "Succeeded"
                                 ]
                             },
@@ -858,7 +854,7 @@
                         },
                         "Get_the_\"All_Computers\"_group": {
                             "runAfter": {
-                                "Initialize_unknown_action_results": [
+                                "Initialize_list_of_unknown_action_results": [
                                     "Succeeded"
                                 ]
                             },
@@ -879,21 +875,20 @@
                                 }
                             }
                         },
-                        "If_Linux_endpoints": {
+                        "Apply_unquarantine_action_to_Linux_endpoints": {
                             "actions": {
                                 "Check_Linux_issued_action_result": {
                                     "actions": {
                                         "Append_Linux_issued_action_result_to_issued_actions": {
-                                            "runAfter": {},
                                             "type": "AppendToArrayVariable",
                                             "inputs": {
                                                 "name": "issuedActions",
-                                                "value": "@body('Issue_Linux_action')?['data']"
+                                                "value": "@body('Issue_Linux_unquarantine_action')?['data']"
                                             }
                                         }
                                     },
                                     "runAfter": {
-                                        "Issue_Linux_action": [
+                                        "Issue_Linux_unquarantine_action": [
                                             "Succeeded"
                                         ]
                                     },
@@ -901,13 +896,16 @@
                                         "and": [
                                             {
                                                 "equals": [
-                                                    "@outputs('Issue_Linux_action')['statusCode']",
+                                                    "@outputs('Issue_Linux_unquarantine_action')['statusCode']",
                                                     200
                                                 ]
                                             }
                                         ]
                                     },
-                                    "type": "If"
+                                    "type": "If",
+                                    "else": {
+                                        "actions": {}
+                                    }
                                 },
                                 "Compose_Linux_action": {
                                     "runAfter": {
@@ -952,8 +950,7 @@
                                         "sub_groups": "@variables('linuxEndpointFilters')"
                                     }
                                 },
-                                "Get_Linux_package": {
-                                    "runAfter": {},
+                                "Get_Linux_unquarantine_package": {
                                     "type": "Http",
                                     "inputs": {
                                         "headers": {
@@ -971,7 +968,7 @@
                                         }
                                     }
                                 },
-                                "Issue_Linux_action": {
+                                "Issue_Linux_unquarantine_action": {
                                     "runAfter": {
                                         "Compose_Linux_action": [
                                             "Succeeded"
@@ -997,13 +994,13 @@
                                 },
                                 "Parse_Linux_package_json": {
                                     "runAfter": {
-                                        "Get_Linux_package": [
+                                        "Get_Linux_unquarantine_package": [
                                             "Succeeded"
                                         ]
                                     },
                                     "type": "ParseJson",
                                     "inputs": {
-                                        "content": "@body('Get_Linux_package')",
+                                        "content": "@body('Get_Linux_unquarantine_package')",
                                         "schema": {
                                             "properties": {
                                                 "data": {
@@ -1114,7 +1111,7 @@
                                 }
                             },
                             "runAfter": {
-                                "If_macOS_endpoints": [
+                                "Apply_unquarantine_action_to_macOS_endpoints": [
                                     "Succeeded"
                                 ]
                             },
@@ -1128,23 +1125,25 @@
                                     }
                                 ]
                             },
-                            "type": "If"
+                            "type": "If",
+                            "else": {
+                                "actions": {}
+                            }
                         },
-                        "If_Windows_endpoints": {
+                        "Apply_unquarantine_action_to_Windows_endpoints": {
                             "actions": {
                                 "Check_Windows_issued_action_result": {
                                     "actions": {
                                         "Append_Windows_issued_action_result_to_issued_actions": {
-                                            "runAfter": {},
                                             "type": "AppendToArrayVariable",
                                             "inputs": {
                                                 "name": "issuedActions",
-                                                "value": "@body('Issue_Windows_action')?['data']"
+                                                "value": "@body('Issue_Windows_unquarantine_action')?['data']"
                                             }
                                         }
                                     },
                                     "runAfter": {
-                                        "Issue_Windows_action": [
+                                        "Issue_Windows_unquarantine_action": [
                                             "Succeeded"
                                         ]
                                     },
@@ -1152,13 +1151,16 @@
                                         "and": [
                                             {
                                                 "equals": [
-                                                    "@outputs('Issue_Windows_action')['statusCode']",
+                                                    "@outputs('Issue_Windows_unquarantine_action')['statusCode']",
                                                     200
                                                 ]
                                             }
                                         ]
                                     },
-                                    "type": "If"
+                                    "type": "If",
+                                    "else": {
+                                        "actions": {}
+                                    }
                                 },
                                 "Compose_Windows_action_package_declaration": {
                                     "runAfter": {
@@ -1203,8 +1205,7 @@
                                         "target_group": "@outputs('Compose_Windows_target_group')"
                                     }
                                 },
-                                "Get_Windows_package": {
-                                    "runAfter": {},
+                                "Get_Windows_unquarantine_package": {
                                     "type": "Http",
                                     "inputs": {
                                         "headers": {
@@ -1222,7 +1223,7 @@
                                         }
                                     }
                                 },
-                                "Issue_Windows_action": {
+                                "Issue_Windows_unquarantine_action": {
                                     "runAfter": {
                                         "Compose_windows_action": [
                                             "Succeeded"
@@ -1248,13 +1249,13 @@
                                 },
                                 "Parse_Windows_package_json": {
                                     "runAfter": {
-                                        "Get_Windows_package": [
+                                        "Get_Windows_unquarantine_package": [
                                             "Succeeded"
                                         ]
                                     },
                                     "type": "ParseJson",
                                     "inputs": {
-                                        "content": "@body('Get_Windows_package')",
+                                        "content": "@body('Get_Windows_unquarantine_package')",
                                         "schema": {
                                             "properties": {
                                                 "data": {
@@ -1365,7 +1366,7 @@
                                 }
                             },
                             "runAfter": {
-                                "For_each_endpoint": [
+                                "For_each_host_on_the_incident": [
                                     "Succeeded"
                                 ]
                             },
@@ -1379,12 +1380,14 @@
                                     }
                                 ]
                             },
-                            "type": "If"
+                            "type": "If",
+                            "else": {
+                                "actions": {}
+                            }
                         },
                         "If_action_results": {
                             "actions": {
-                                "Add_comment_to_incident_(V3)_-_action_results": {
-                                    "runAfter": {},
+                                "Add_comment_to_incident_-_known_action_results": {
                                     "type": "ApiConnection",
                                     "inputs": {
                                         "body": {
@@ -1408,8 +1411,7 @@
                             },
                             "else": {
                                 "actions": {
-                                    "Add_comment_to_incident_(V3)_-_unknown_action_results": {
-                                        "runAfter": {},
+                                    "Add_comment_to_incident_-_unknown_action_results": {
                                         "type": "ApiConnection",
                                         "inputs": {
                                             "body": {
@@ -1441,8 +1443,7 @@
                         },
                         "If_action_results_and_unknown_action_results": {
                             "actions": {
-                                "Add_comment_to_incident_(V3)_-_known_and_unknown_action_results": {
-                                    "runAfter": {},
+                                "Add_comment_to_incident_-_known_and_unknown_action_results": {
                                     "type": "ApiConnection",
                                     "inputs": {
                                         "body": {
@@ -1460,7 +1461,7 @@
                                 },
                                 "Terminate_2": {
                                     "runAfter": {
-                                        "Add_comment_to_incident_(V3)_-_known_and_unknown_action_results": [
+                                        "Add_comment_to_incident_-_known_and_unknown_action_results": [
                                             "Succeeded"
                                         ]
                                     },
@@ -1491,23 +1492,25 @@
                                     }
                                 ]
                             },
-                            "type": "If"
+                            "type": "If",
+                            "else": {
+                                "actions": {}
+                            }
                         },
-                        "If_macOS_endpoints": {
+                        "Apply_unquarantine_action_to_macOS_endpoints": {
                             "actions": {
                                 "Check_macOS_issued_action_result": {
                                     "actions": {
                                         "Append_macOS_issued_action_result_to_issued_actions": {
-                                            "runAfter": {},
                                             "type": "AppendToArrayVariable",
                                             "inputs": {
                                                 "name": "issuedActions",
-                                                "value": "@body('Issue_macOS_action')?['data']"
+                                                "value": "@body('Issue_macOS_unquarantine_action')?['data']"
                                             }
                                         }
                                     },
                                     "runAfter": {
-                                        "Issue_macOS_action": [
+                                        "Issue_macOS_unquarantine_action": [
                                             "Succeeded"
                                         ]
                                     },
@@ -1515,13 +1518,16 @@
                                         "and": [
                                             {
                                                 "equals": [
-                                                    "@body('Issue_macOS_action')",
+                                                    "@body('Issue_macOS_unquarantine_action')",
                                                     200
                                                 ]
                                             }
                                         ]
                                     },
-                                    "type": "If"
+                                    "type": "If",
+                                    "else": {
+                                        "actions": {}
+                                    }
                                 },
                                 "Compose_macOS_action": {
                                     "runAfter": {
@@ -1566,8 +1572,7 @@
                                         "sub_groups": "@variables('macOsEndpointFilters')"
                                     }
                                 },
-                                "Get_macOS_package": {
-                                    "runAfter": {},
+                                "Get_macOS_unquarantine_package": {
                                     "type": "Http",
                                     "inputs": {
                                         "headers": {
@@ -1585,7 +1590,7 @@
                                         }
                                     }
                                 },
-                                "Issue_macOS_action": {
+                                "Issue_macOS_unquarantine_action": {
                                     "runAfter": {
                                         "Compose_macOS_action": [
                                             "Succeeded"
@@ -1611,13 +1616,13 @@
                                 },
                                 "Parse_macOS_package_json": {
                                     "runAfter": {
-                                        "Get_macOS_package": [
+                                        "Get_macOS_unquarantine_package": [
                                             "Succeeded"
                                         ]
                                     },
                                     "type": "ParseJson",
                                     "inputs": {
-                                        "content": "@body('Get_macOS_package')",
+                                        "content": "@body('Get_macOS_unquarantine_package')",
                                         "schema": {
                                             "properties": {
                                                 "data": {
@@ -1728,7 +1733,7 @@
                                 }
                             },
                             "runAfter": {
-                                "If_Windows_endpoints": [
+                                "Apply_unquarantine_action_to_Windows_endpoints": [
                                     "Succeeded"
                                 ]
                             },
@@ -1742,11 +1747,14 @@
                                     }
                                 ]
                             },
-                            "type": "If"
+                            "type": "If",
+                            "else": {
+                                "actions": {}
+                            }
                         },
-                        "Initialize_API_Gateway_Query": {
+                        "Initialize_API_Query": {
                             "runAfter": {
-                                "Initialize_package_parameters": [
+                                "Initialize_unquarantine_package_parameters": [
                                     "Succeeded"
                                 ]
                             },
@@ -1761,7 +1769,7 @@
                                 ]
                             }
                         },
-                        "Initialize_API_Gateway_Query_Variables": {
+                        "Initialize_API_Variables": {
                             "runAfter": {
                                 "Initialize_Tanium_Endpoint_Source_to_TDS": [
                                     "Succeeded"
@@ -1778,9 +1786,9 @@
                                 ]
                             }
                         },
-                        "Initialize_API_Gateway_Response": {
+                        "Initialize_API_Response": {
                             "runAfter": {
-                                "Query_API_Gateway": [
+                                "Get_General_Host_Info": [
                                     "Succeeded"
                                 ]
                             },
@@ -1790,15 +1798,14 @@
                                     {
                                         "name": "apiResponse",
                                         "type": "object",
-                                        "value": "@body('Query_API_Gateway')"
+                                        "value": "@body('Get_General_Host_Info')"
                                     }
                                 ]
                             }
                         },
-                        "Stop_If_Tanium_Has_No_Hosts_From_Incident": {
+                        "Exit_early_If_Tanium_Has_No_Data_for_Incident": {
                             "actions": {
-                                "Add_comment_to_incident_(V3)_3": {
-                                    "runAfter": {},
+                                "Add_comment__-_no_data_in_Tanium": {
                                     "type": "ApiConnection",
                                     "inputs": {
                                         "body": {
@@ -1814,9 +1821,9 @@
                                         "path": "/Incidents/Comment"
                                     }
                                 },
-                                "Terminate_no_hosts_in_Tanium": {
+                                "Exit_early__-_no_data_in_Tanium": {
                                     "runAfter": {
-                                        "Add_comment_to_incident_(V3)_3": [
+                                        "Add_comment__-_no_data_in_Tanium": [
                                             "Succeeded"
                                         ]
                                     },
@@ -1827,7 +1834,7 @@
                                 }
                             },
                             "runAfter": {
-                                "Parse_API_Gateway_response": [
+                                "Parse_API_response": [
                                     "Succeeded"
                                 ]
                             },
@@ -1835,17 +1842,20 @@
                                 "and": [
                                     {
                                         "equals": [
-                                            "@body('Parse_API_Gateway_response')?['data']?['endpoints']?['pageInfo']?['endCursor']",
+                                            "@body('Parse_API_response')?['data']?['endpoints']?['pageInfo']?['endCursor']",
                                             "@null"
                                         ]
                                     }
                                 ]
                             },
-                            "type": "If"
+                            "type": "If",
+                            "else": {
+                                "actions": {}
+                            }
                         },
-                        "Initialize_API_Gateway_query_cursor": {
+                        "Initialize_cursor": {
                             "runAfter": {
-                                "Stop_If_Tanium_Has_No_Hosts_From_Incident": [
+                                "Exit_early_If_Tanium_Has_No_Data_for_Incident": [
                                     "Succeeded"
                                 ]
                             },
@@ -1855,14 +1865,14 @@
                                     {
                                         "name": "cursor",
                                         "type": "string",
-                                        "value": "@body('Parse_API_Gateway_response')?['data']?['endpoints']?['pageInfo']?['endCursor']"
+                                        "value": "@body('Parse_API_response')?['data']?['endpoints']?['pageInfo']?['endCursor']"
                                     }
                                 ]
                             }
                         },
                         "Initialize_Endpoint_Filter": {
                             "runAfter": {
-                                "Initialize_API_Gateway_Query": [
+                                "Initialize_API_Query": [
                                     "Succeeded"
                                 ]
                             },
@@ -1876,9 +1886,9 @@
                                 ]
                             }
                         },
-                        "Initialize_Linux_endpoint_filters": {
+                        "Initialize_the_filter_for_Linux_endpoint(s)": {
                             "runAfter": {
-                                "Initialize_Windows_endpoint_filters": [
+                                "Initialize_the_filter_for_Windows_endpoint(s)": [
                                     "Succeeded"
                                 ]
                             },
@@ -1892,9 +1902,9 @@
                                 ]
                             }
                         },
-                        "Initialize_Linux_package_name": {
+                        "Initialize_the_name_of_the_Linux_unquarantine_package": {
                             "runAfter": {
-                                "Initialize_MacOS_package_name": [
+                                "Initialize_the_name_of_the_MacOS_unquarantine_package": [
                                     "Succeeded"
                                 ]
                             },
@@ -1909,9 +1919,9 @@
                                 ]
                             }
                         },
-                        "Initialize_MacOS_package_name": {
+                        "Initialize_the_name_of_the_MacOS_unquarantine_package": {
                             "runAfter": {
-                                "Initialize_Windows_package_name": [
+                                "Initialize_the_name_of_the_Windows_unquarantine_package": [
                                     "Succeeded"
                                 ]
                             },
@@ -1945,7 +1955,7 @@
                                 ]
                             }
                         },
-                        "Initialize_Windows_endpoint_filters": {
+                        "Initialize_the_filter_for_Windows_endpoint(s)": {
                             "runAfter": {
                                 "Add_comment_to_incident_-_hosts_that_will_be_targeted": [
                                     "Succeeded"
@@ -1961,9 +1971,9 @@
                                 ]
                             }
                         },
-                        "Initialize_Windows_package_name": {
+                        "Initialize_the_name_of_the_Windows_unquarantine_package": {
                             "runAfter": {
-                                "Exit_early_if_no_hosts_are_found": [
+                                "Exit_early_if_incident_has_no_hosts": [
                                     "Succeeded"
                                 ]
                             },
@@ -1994,7 +2004,7 @@
                                 ]
                             }
                         },
-                        "Initialize_all_computers_id": {
+                        "Initialize_allComputersGroupId": {
                             "runAfter": {
                                 "Get_the_\"All_Computers\"_group": [
                                     "Succeeded"
@@ -2013,7 +2023,7 @@
                         },
                         "Initialize_endpoints_array": {
                             "runAfter": {
-                                "Initialize_API_Gateway_query_cursor": [
+                                "Initialize_cursor": [
                                     "Succeeded"
                                 ]
                             },
@@ -2023,14 +2033,14 @@
                                     {
                                         "name": "endpoints",
                                         "type": "array",
-                                        "value": "@body('Parse_API_Gateway_response')?['data']?['endpoints']?['edges']"
+                                        "value": "@body('Parse_API_response')?['data']?['endpoints']?['edges']"
                                     }
                                 ]
                             }
                         },
-                        "Initialize_issued_actions": {
+                        "Initialize_list_of_issued_actions": {
                             "runAfter": {
-                                "Initialize_macOS_endpoint_filters": [
+                                "Initialize_the_filter_for_macOS_endpoint(s)": [
                                     "Succeeded"
                                 ]
                             },
@@ -2044,9 +2054,9 @@
                                 ]
                             }
                         },
-                        "Initialize_macOS_endpoint_filters": {
+                        "Initialize_the_filter_for_macOS_endpoint(s)": {
                             "runAfter": {
-                                "Initialize_Linux_endpoint_filters": [
+                                "Initialize_the_filter_for_Linux_endpoint(s)": [
                                     "Succeeded"
                                 ]
                             },
@@ -2060,9 +2070,9 @@
                                 ]
                             }
                         },
-                        "Initialize_package_parameters": {
+                        "Initialize_unquarantine_package_parameters": {
                             "runAfter": {
-                                "Initialize_Linux_package_name": [
+                                "Initialize_the_name_of_the_Linux_unquarantine_package": [
                                     "Succeeded"
                                 ]
                             },
@@ -2077,9 +2087,9 @@
                             },
                             "description": "The un-quarantine packages have no parameters"
                         },
-                        "Initialize_unknown_action_results": {
+                        "Initialize_list_of_unknown_action_results": {
                             "runAfter": {
-                                "Initialize_issued_actions": [
+                                "Initialize_list_of_issued_actions": [
                                     "Succeeded"
                                 ]
                             },
@@ -2093,15 +2103,14 @@
                                 ]
                             }
                         },
-                        "Paginate_API_Gateway_query_if_needed": {
+                        "Loop_Paginated_Response_if_has_multiple_pages": {
                             "actions": {
-                                "Until_there_are_no_more_pages_in_the_API_gateway_response": {
+                                "Until_no_more_pages": {
                                     "actions": {
                                         "For_each_endpoint_in_paginated_API_Gateway_response": {
-                                            "foreach": "@body('Parse_paginated_API_Gateway_response')?['data']?['endpoints']?['edges']",
+                                            "foreach": "@body('Parse_page')?['data']?['endpoints']?['edges']",
                                             "actions": {
                                                 "Append_endpoint_to_endpoints": {
-                                                    "runAfter": {},
                                                     "type": "AppendToArrayVariable",
                                                     "inputs": {
                                                         "name": "endpoints",
@@ -2110,7 +2119,7 @@
                                                 }
                                             },
                                             "runAfter": {
-                                                "Update_API_Gateway_query_cursor": [
+                                                "Update_cursor_to_next_page": [
                                                     "Succeeded"
                                                 ]
                                             },
@@ -2121,9 +2130,9 @@
                                                 }
                                             }
                                         },
-                                        "Paginate_API_Gateway": {
+                                        "Get_next_page": {
                                             "runAfter": {
-                                                "Update_API_Gateway_query_variables": [
+                                                "Update_cursor_for_next_page": [
                                                     "Succeeded"
                                                 ]
                                             },
@@ -2148,15 +2157,15 @@
                                                 }
                                             }
                                         },
-                                        "Parse_paginated_API_Gateway_response": {
+                                        "Parse_page": {
                                             "runAfter": {
-                                                "Paginate_API_Gateway": [
+                                                "Get_next_page": [
                                                     "Succeeded"
                                                 ]
                                             },
                                             "type": "ParseJson",
                                             "inputs": {
-                                                "content": "@body('Paginate_API_Gateway')",
+                                                "content": "@body('Get_next_page')",
                                                 "schema": {
                                                     "properties": {
                                                         "data": {
@@ -2199,20 +2208,19 @@
                                                 }
                                             }
                                         },
-                                        "Update_API_Gateway_query_cursor": {
+                                        "Update_cursor_to_next_page": {
                                             "runAfter": {
-                                                "Parse_paginated_API_Gateway_response": [
+                                                "Parse_page": [
                                                     "Succeeded"
                                                 ]
                                             },
                                             "type": "SetVariable",
                                             "inputs": {
                                                 "name": "cursor",
-                                                "value": "@body('Parse_paginated_API_Gateway_response')?['data']?['endpoints']?['pageInfo']?['endCursor']"
+                                                "value": "@body('Parse_page')?['data']?['endpoints']?['pageInfo']?['endCursor']"
                                             }
                                         },
-                                        "Update_API_Gateway_query_variables": {
-                                            "runAfter": {},
+                                        "Update_cursor_for_next_page": {
                                             "type": "SetVariable",
                                             "inputs": {
                                                 "name": "apiQuery",
@@ -2220,8 +2228,7 @@
                                             }
                                         }
                                     },
-                                    "runAfter": {},
-                                    "expression": "@equals(body('Parse_paginated_API_Gateway_response')?['data']?['endpoints']?['pageInfo']?['hasNextPage'], false)",
+                                    "expression": "@equals(body('Parse_page')?['data']?['endpoints']?['pageInfo']?['hasNextPage'],false)",
                                     "limit": {
                                         "count": 60,
                                         "timeout": "PT1H"
@@ -2238,15 +2245,18 @@
                                 "and": [
                                     {
                                         "equals": [
-                                            "@body('Parse_API_Gateway_response')?['data']?['endpoints']?['pageInfo']?['hasNextPage']",
+                                            "@body('Parse_API_response')?['data']?['endpoints']?['pageInfo']?['hasNextPage']",
                                             "@true"
                                         ]
                                     }
                                 ]
                             },
-                            "type": "If"
+                            "type": "If",
+                            "else": {
+                                "actions": {}
+                            }
                         },
-                        "Parse_API_Gateway_response": {
+                        "Parse_API_response": {
                             "runAfter": {
                                 "Switch_to_TS_from_TDS_if_needed": [
                                     "Succeeded"
@@ -2314,7 +2324,7 @@
                         },
                         "Parse_endpoints_array": {
                             "runAfter": {
-                                "Paginate_API_Gateway_query_if_needed": [
+                                "Loop_Paginated_Response_if_has_multiple_pages": [
                                     "Succeeded"
                                 ]
                             },
@@ -2327,9 +2337,9 @@
                             },
                             "description": "We need an action's output to use in the JavaScript code since it can't read from a variable"
                         },
-                        "Query_API_Gateway": {
+                        "Get_General_Host_Info": {
                             "runAfter": {
-                                "Initialize_API_Gateway_Query_Variables": [
+                                "Initialize_API_Variables": [
                                     "Succeeded"
                                 ]
                             },
@@ -2356,7 +2366,7 @@
                         },
                         "Select_expire_seconds": {
                             "runAfter": {
-                                "Add_comment_to_incident_(V3)_2": [
+                                "Add_Issued_Actions_to_Incident": [
                                     "Succeeded"
                                 ]
                             },
@@ -2386,7 +2396,6 @@
                                         },
                                         "method": "POST",
                                         "uri": "@parameters('TaniumApiGatewayApi')"
-
                                     },
                                     "runtimeConfiguration": {
                                         "secureData": {
@@ -2396,8 +2405,7 @@
                                         }
                                     }
                                 },
-                                "Set_Tanium_Endpoint_Source_to_TS": {
-                                    "runAfter": {},
+                                "Change_Endpoint_Source_to_TS": {
                                     "type": "SetVariable",
                                     "inputs": {
                                         "name": "endpointSource",
@@ -2422,7 +2430,7 @@
                                 },
                                 "Update_API_Query_variables_to_get_new_source": {
                                     "runAfter": {
-                                        "Set_Tanium_Endpoint_Source_to_TS": [
+                                        "Change_Endpoint_Source_to_TS": [
                                             "Succeeded"
                                         ]
                                     },
@@ -2434,7 +2442,7 @@
                                 }
                             },
                             "runAfter": {
-                                "Initialize_API_Gateway_Response": [
+                                "Initialize_API_Response": [
                                     "Succeeded"
                                 ]
                             },
@@ -2442,13 +2450,16 @@
                                 "and": [
                                     {
                                         "contains": [
-                                            "@string(body('Query_API_Gateway'))",
+                                            "@string(body('Get_General_Host_Info'))",
                                             "must refer to an existing sensor"
                                         ]
                                     }
                                 ]
                             },
-                            "type": "If"
+                            "type": "If",
+                            "else": {
+                                "actions": {}
+                            }
                         },
                         "Wait_for_the_max_expire_seconds_from_the_issued_actions": {
                             "runAfter": {

--- a/Solutions/Tanium/Playbooks/Tanium-UnquarantineHosts/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-UnquarantineHosts/azuredeploy.json
@@ -80,7 +80,7 @@
         },
         {
             "type": "Microsoft.Logic/workflows",
-            "apiVersion": "2019-05-01",
+            "apiVersion": "2016-06-01",
             "name": "[parameters('PlaybookName')]",
             "location": "[resourceGroup().location]",
             "tags": {

--- a/Solutions/Tanium/Playbooks/Tanium-UnquarantineHosts/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-UnquarantineHosts/azuredeploy.json
@@ -2215,7 +2215,7 @@
                                             "runAfter": {},
                                             "type": "SetVariable",
                                             "inputs": {
-                                                "name": "apiVariables",
+                                                "name": "apiQuery",
                                                 "value": "{\n  \"source\": @{variables('endpointSource')},\n  \"endCursor\": \"@{variables('cursor')}\"\n}"
                                             }
                                         }

--- a/Solutions/Tanium/Playbooks/Tanium-UnquarantineHosts/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-UnquarantineHosts/azuredeploy.json
@@ -1352,7 +1352,7 @@
                                 "variables": [
                                     {
                                         "name": "allComputersGroupId",
-                                        "type": "string"
+                                        "type": "integer"
                                     }
                                 ]
                             },

--- a/Solutions/Tanium/Playbooks/Tanium-UnquarantineHosts/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-UnquarantineHosts/azuredeploy.json
@@ -21,12 +21,19 @@
         "author": {
             "name": "Tanium"
         },
-        "parameterTemplateVersion": "2.0.1"
+        "parameterTemplateVersion": "3.0.0"
     },
     "parameters": {
         "PlaybookName": {
             "defaultValue": "Tanium-UnquarantineHosts",
             "type": "string"
+        },
+        "AzureSentinelConnectionName": {
+            "defaultValue": "Tanium-QuarantineHosts-Sentinel-WebConn",
+            "type": "string",
+            "metadata": {
+                "description": "The name to use for the Sentinel Connector in the Logic App . (This will exist as an API Connection in your subscription)"
+            }
         },
         "IntegrationAccountName": {
             "defaultValue": "",
@@ -57,7 +64,6 @@
         }
     },
     "variables": {
-        "AzureSentinelConnectionName": "[concat('azuresentinel-', parameters('PlaybookName'))]",
         "TaniumActionsApi": "[uri(concat('https://', parameters('TaniumServerHostname')), '/api/v2/actions')]",
         "TaniumAllComputersUrl": "[uri(concat('https://', parameters('TaniumServerHostname')), '/api/v2/groups/by-name/All%20Computers')]",
         "TaniumPackagesByNameUrlFragment": "[uri(concat('https://', parameters('TaniumServerHostname')), '/api/v2/packages/by-name/')]",
@@ -68,14 +74,15 @@
         {
             "type": "Microsoft.Web/connections",
             "apiVersion": "2018-07-01-preview",
-            "name": "[variables('AzureSentinelConnectionName')]",
+            "name": "[parameters('AzureSentinelConnectionName')]",
             "location": "[resourceGroup().location]",
             "properties": {
-                "displayName": "[variables('AzureSentinelConnectionName')]",
+                "displayName": "[parameters('AzureSentinelConnectionName')]",
                 "customParameterValues": {},
                 "api": {
                     "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/azuresentinel')]"
-                }
+                },
+                "parameterValueType": "Alternative"
             }
         },
         {
@@ -83,12 +90,15 @@
             "apiVersion": "2016-06-01",
             "name": "[parameters('PlaybookName')]",
             "location": "[resourceGroup().location]",
+            "identity": {
+                "type": "SystemAssigned"
+            },
             "tags": {
                 "hidden-SentinelTemplateName": "Tanium-UnquarantineHosts",
                 "hidden-SentinelTemplateVersion": "2.0"
             },
             "dependsOn": [
-                "[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]"
+                "[resourceId('Microsoft.Web/connections', parameters('AzureSentinelConnectionName'))]"
             ],
             "properties": {
                 "state": "Enabled",
@@ -2576,9 +2586,14 @@
                     "$connections": {
                         "value": {
                             "azuresentinel": {
-                                "connectionName": "[variables('AzureSentinelConnectionName')]",
-                                "connectionId": "[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]",
-                                "id": "[concat('/subscriptions/',subscription().subscriptionId, '/providers/Microsoft.Web/locations/',resourceGroup().location,'/managedApis/azuresentinel')]"
+                                "connectionName": "[parameters('AzureSentinelConnectionName')]",
+                                "connectionId": "[resourceId('Microsoft.Web/connections', parameters('AzureSentinelConnectionName'))]",
+                                "id": "[concat('/subscriptions/',subscription().subscriptionId, '/providers/Microsoft.Web/locations/',resourceGroup().location,'/managedApis/azuresentinel')]",
+                                "connectionProperties": {
+                                    "authentication": {
+                                        "type": "ManagedServiceIdentity"
+                                    }
+                                }
                             }
                         }
                     },

--- a/Solutions/Tanium/Playbooks/Tanium-UnquarantineHosts/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-UnquarantineHosts/azuredeploy.json
@@ -206,7 +206,7 @@
                                 "and": [
                                     {
                                         "less": [
-                                            "@length(variables('issued actions'))",
+                                            "@length(variables('issuedActions'))",
                                             1
                                         ]
                                     }
@@ -215,7 +215,7 @@
                             "type": "If"
                         },
                         "Collect_action_results_for_each_issued_action": {
-                            "foreach": "@variables('issued actions')",
+                            "foreach": "@variables('issuedActions')",
                             "actions": {
                                 "Get_action_result": {
                                     "runAfter": {},
@@ -245,7 +245,7 @@
                                                     "runAfter": {},
                                                     "type": "AppendToArrayVariable",
                                                     "inputs": {
-                                                        "name": "action results",
+                                                        "name": "knownActionResults",
                                                         "value": "@item()"
                                                     }
                                                 }
@@ -269,7 +269,7 @@
                                                 },
                                                 "type": "AppendToArrayVariable",
                                                 "inputs": {
-                                                    "name": "unknown action results",
+                                                    "name": "unknownActionResults",
                                                     "value": "@outputs('Compose_unknown_action_result')"
                                                 }
                                             },
@@ -585,7 +585,7 @@
                             "type": "Table",
                             "inputs": {
                                 "format": "HTML",
-                                "from": "@variables('action results')"
+                                "from": "@variables('knownActionResults')"
                             }
                         },
                         "Create_HTML_table_of_issued_actions": {
@@ -611,7 +611,7 @@
                                     }
                                 ],
                                 "format": "HTML",
-                                "from": "@variables('issued actions')"
+                                "from": "@variables('issuedActions')"
                             }
                         },
                         "Create_HTML_table_of_matched_endpoints": {
@@ -635,7 +635,7 @@
                             "type": "Table",
                             "inputs": {
                                 "format": "HTML",
-                                "from": "@variables('unknown action results')"
+                                "from": "@variables('unknownActionResults')"
                             }
                         },
                         "Get_Hosts_From_Incident": {
@@ -786,7 +786,7 @@
                                                     "runAfter": {},
                                                     "type": "AppendToArrayVariable",
                                                     "inputs": {
-                                                        "name": "linux endpoint filters",
+                                                        "name": "linuxEndpointFilters",
                                                         "value": "@outputs('Compose_endpoint_filter_for_packages')"
                                                     }
                                                 }
@@ -799,7 +799,7 @@
                                                     "runAfter": {},
                                                     "type": "AppendToArrayVariable",
                                                     "inputs": {
-                                                        "name": "macos endpoint filters",
+                                                        "name": "macOsEndpointFilters",
                                                         "value": "@outputs('Compose_endpoint_filter_for_packages')"
                                                     }
                                                 }
@@ -812,7 +812,7 @@
                                                     "runAfter": {},
                                                     "type": "AppendToArrayVariable",
                                                     "inputs": {
-                                                        "name": "windows endpoint filters",
+                                                        "name": "windowsEndpointFilters",
                                                         "value": "@outputs('Compose_endpoint_filter_for_packages')"
                                                     }
                                                 }
@@ -846,7 +846,7 @@
                         },
                         "Set_Endpoint_Filter": {
                             "inputs": {
-                                "name": "endpoint filters",
+                                "name": "endpointFilters",
                                 "value": "@body('Build_Endpoint_Filter_from_Hosts')"
                             },
                             "runAfter": {
@@ -887,7 +887,7 @@
                                             "runAfter": {},
                                             "type": "AppendToArrayVariable",
                                             "inputs": {
-                                                "name": "issued actions",
+                                                "name": "issuedActions",
                                                 "value": "@body('Issue_Linux_action')?['data']"
                                             }
                                         }
@@ -918,11 +918,11 @@
                                     "type": "Compose",
                                     "inputs": {
                                         "action_group": {
-                                            "id": "@variables('all computers id')"
+                                            "id": "@variables('allComputersGroupId')"
                                         },
                                         "distribute_seconds": 0,
                                         "expire_seconds": "@body('Parse_Linux_package_json')?['data']?['expire_seconds']",
-                                        "name": "Apply from Microsoft Sentinel: @{variables('linux package name')}",
+                                        "name": "Apply from Microsoft Sentinel: @{variables('linuxPackageName')}",
                                         "package_spec": "@outputs('Compose_Linux_action_package_declaration')",
                                         "target_group": "@outputs('Compose_Linux_target_group')"
                                     }
@@ -936,7 +936,7 @@
                                     "type": "Compose",
                                     "inputs": {
                                         "expire_seconds": "@body('Parse_Linux_package_json')?['data']?['expire_seconds']",
-                                        "parameters": "@variables('package parameters')",
+                                        "parameters": "@variables('packageParameters')",
                                         "source_id": "@body('Parse_Linux_package_json')?['data']?['id']"
                                     }
                                 },
@@ -949,7 +949,7 @@
                                     "type": "Compose",
                                     "inputs": {
                                         "and_flag": false,
-                                        "sub_groups": "@variables('linux endpoint filters')"
+                                        "sub_groups": "@variables('linuxEndpointFilters')"
                                     }
                                 },
                                 "Get_Linux_package": {
@@ -961,7 +961,7 @@
                                             "session": "@parameters('TaniumApiToken')"
                                         },
                                         "method": "GET",
-                                        "uri": "@{concat(parameters('TaniumPackagesByNameUrlFragment'), join(split(variables('linux package name'), ' '), '%20'))}"
+                                        "uri": "@{concat(parameters('TaniumPackagesByNameUrlFragment'), join(split(variables('linuxPackageName'), ' '), '%20'))}"
                                     },
                                     "runtimeConfiguration": {
                                         "secureData": {
@@ -1122,7 +1122,7 @@
                                 "and": [
                                     {
                                         "greater": [
-                                            "@length(variables('linux endpoint filters'))",
+                                            "@length(variables('linuxEndpointFilters'))",
                                             0
                                         ]
                                     }
@@ -1138,7 +1138,7 @@
                                             "runAfter": {},
                                             "type": "AppendToArrayVariable",
                                             "inputs": {
-                                                "name": "issued actions",
+                                                "name": "issuedActions",
                                                 "value": "@body('Issue_Windows_action')?['data']"
                                             }
                                         }
@@ -1169,7 +1169,7 @@
                                     "type": "Compose",
                                     "inputs": {
                                         "expire_seconds": "@body('Parse_Windows_package_json')?['data']?['expire_seconds']",
-                                        "parameters": "@variables('package parameters')",
+                                        "parameters": "@variables('packageParameters')",
                                         "source_id": "@body('Parse_Windows_package_json')?['data']?['id']"
                                     }
                                 },
@@ -1182,7 +1182,7 @@
                                     "type": "Compose",
                                     "inputs": {
                                         "and_flag": false,
-                                        "sub_groups": "@variables('windows endpoint filters')"
+                                        "sub_groups": "@variables('windowsEndpointFilters')"
                                     }
                                 },
                                 "Compose_windows_action": {
@@ -1194,11 +1194,11 @@
                                     "type": "Compose",
                                     "inputs": {
                                         "action_group": {
-                                            "id": "@variables('all computers id')"
+                                            "id": "@variables('allComputersGroupId')"
                                         },
                                         "distribute_seconds": 0,
                                         "expire_seconds": "@body('Parse_Windows_package_json')?['data']?['expire_seconds']",
-                                        "name": "Apply from Microsoft Sentinel: @{variables('windows package name')}",
+                                        "name": "Apply from Microsoft Sentinel: @{variables('windowsPackageName')}",
                                         "package_spec": "@outputs('Compose_Windows_action_package_declaration')",
                                         "target_group": "@outputs('Compose_Windows_target_group')"
                                     }
@@ -1212,7 +1212,7 @@
                                             "session": "@parameters('TaniumApiToken')"
                                         },
                                         "method": "GET",
-                                        "uri": "@{concat(parameters('TaniumPackagesByNameUrlFragment'), join(split(variables('windows package name'), ' '), '%20'))}"
+                                        "uri": "@{concat(parameters('TaniumPackagesByNameUrlFragment'), join(split(variables('windowsPackageName'), ' '), '%20'))}"
                                     },
                                     "runtimeConfiguration": {
                                         "secureData": {
@@ -1373,7 +1373,7 @@
                                 "and": [
                                     {
                                         "greater": [
-                                            "@length(variables('windows endpoint filters'))",
+                                            "@length(variables('windowsEndpointFilters'))",
                                             0
                                         ]
                                     }
@@ -1431,7 +1431,7 @@
                                 "and": [
                                     {
                                         "greater": [
-                                            "@length(variables('action results'))",
+                                            "@length(variables('knownActionResults'))",
                                             0
                                         ]
                                     }
@@ -1479,13 +1479,13 @@
                                 "and": [
                                     {
                                         "greater": [
-                                            "@length(variables('action results'))",
+                                            "@length(variables('knownActionResults'))",
                                             0
                                         ]
                                     },
                                     {
                                         "greater": [
-                                            "@length(variables('unknown action results'))",
+                                            "@length(variables('unknownActionResults'))",
                                             0
                                         ]
                                     }
@@ -1501,7 +1501,7 @@
                                             "runAfter": {},
                                             "type": "AppendToArrayVariable",
                                             "inputs": {
-                                                "name": "issued actions",
+                                                "name": "issuedActions",
                                                 "value": "@body('Issue_macOS_action')?['data']"
                                             }
                                         }
@@ -1532,11 +1532,11 @@
                                     "type": "Compose",
                                     "inputs": {
                                         "action_group": {
-                                            "id": "@variables('all computers id')"
+                                            "id": "@variables('allComputersGroupId')"
                                         },
                                         "distribute_seconds": 0,
                                         "expire_seconds": "@body('Parse_macOS_package_json')?['data']?['expire_seconds']",
-                                        "name": "Apply from Microsoft Sentinel @{variables('macos package name')}",
+                                        "name": "Apply from Microsoft Sentinel @{variables('macOsPackageName')}",
                                         "package_spec": "@outputs('Compose_macOS_action_package_declaration')",
                                         "target_group": "@outputs('Compose_macOS_target_group')"
                                     }
@@ -1550,7 +1550,7 @@
                                     "type": "Compose",
                                     "inputs": {
                                         "expire_seconds": "@body('Parse_macOS_package_json')?['data']?['expire_seconds']",
-                                        "parameters": "@variables('package parameters')",
+                                        "parameters": "@variables('packageParameters')",
                                         "source_id": "@body('Parse_macOS_package_json')?['data']?['id']"
                                     }
                                 },
@@ -1563,7 +1563,7 @@
                                     "type": "Compose",
                                     "inputs": {
                                         "and_flag": false,
-                                        "sub_groups": "@variables('macos endpoint filters')"
+                                        "sub_groups": "@variables('macOsEndpointFilters')"
                                     }
                                 },
                                 "Get_macOS_package": {
@@ -1575,7 +1575,7 @@
                                             "session": "@parameters('TaniumApiToken')"
                                         },
                                         "method": "GET",
-                                        "uri": "@{concat(parameters('TaniumPackagesByNameUrlFragment'), join(split(variables('macos package name'), ' '), '%20'))}"
+                                        "uri": "@{concat(parameters('TaniumPackagesByNameUrlFragment'), join(split(variables('macOsPackageName'), ' '), '%20'))}"
                                     },
                                     "runtimeConfiguration": {
                                         "secureData": {
@@ -1736,7 +1736,7 @@
                                 "and": [
                                     {
                                         "greater": [
-                                            "@length(variables('macos endpoint filters'))",
+                                            "@length(variables('macOsEndpointFilters'))",
                                             0
                                         ]
                                     }
@@ -1754,7 +1754,7 @@
                             "inputs": {
                                 "variables": [
                                     {
-                                        "name": "api gateway query",
+                                        "name": "apiQuery",
                                         "type": "string",
                                         "value": "query ($incidentHosts: EndpointFieldFilter, $endCursor: Cursor, $source: EndpointSource) {\n  endpoints(\n    source: $source\n    first: 10\n    after: $endCursor\n    filter: $incidentHosts\n  ) {\n    edges {\n      node {\n        name\n        ipAddress\n        os { platform }\n      }\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}"
                                     }
@@ -1771,9 +1771,9 @@
                             "inputs": {
                                 "variables": [
                                     {
-                                        "name": "api gateway query variables",
+                                        "name": "apiVariables",
                                         "type": "string",
-                                        "value": "{\n  \"source\": @{variables('Tanium Endpoint Source')},\n  \"incidentHosts\": {\n    \"any\": true,\n    \"filters\": @{variables('endpoint filters')}\n  }\n}"
+                                        "value": "{\n  \"source\": @{variables('endpointSource')},\n  \"incidentHosts\": {\n    \"any\": true,\n    \"filters\": @{variables('endpointFilters')}\n  }\n}"
                                     }
                                 ]
                             }
@@ -1788,7 +1788,7 @@
                             "inputs": {
                                 "variables": [
                                     {
-                                        "name": "API Gateway Response",
+                                        "name": "apiResponse",
                                         "type": "object",
                                         "value": "@body('Query_API_Gateway')"
                                     }
@@ -1870,7 +1870,7 @@
                             "inputs": {
                                 "variables": [
                                     {
-                                        "name": "endpoint filters",
+                                        "name": "endpointFilters",
                                         "type": "array"
                                     }
                                 ]
@@ -1886,7 +1886,7 @@
                             "inputs": {
                                 "variables": [
                                     {
-                                        "name": "linux endpoint filters",
+                                        "name": "linuxEndpointFilters",
                                         "type": "array"
                                     }
                                 ]
@@ -1902,7 +1902,7 @@
                             "inputs": {
                                 "variables": [
                                     {
-                                        "name": "linux package name",
+                                        "name": "linuxPackageName",
                                         "type": "string",
                                         "value": "Remove Linux IPTables Quarantine"
                                     }
@@ -1919,7 +1919,7 @@
                             "inputs": {
                                 "variables": [
                                     {
-                                        "name": "macos package name",
+                                        "name": "macOsPackageName",
                                         "type": "string",
                                         "value": "Remove Mac PF Quarantine"
                                     }
@@ -1936,7 +1936,7 @@
                             "inputs": {
                                 "variables": [
                                     {
-                                        "name": "tanium endpoint source",
+                                        "name": "endpointSource",
                                         "type": "object",
                                         "value": {
                                             "tds": {}
@@ -1955,7 +1955,7 @@
                             "inputs": {
                                 "variables": [
                                     {
-                                        "name": "windows endpoint filters",
+                                        "name": "windowsEndpointFilters",
                                         "type": "array"
                                     }
                                 ]
@@ -1971,7 +1971,7 @@
                             "inputs": {
                                 "variables": [
                                     {
-                                        "name": "windows package name",
+                                        "name": "windowsPackageName",
                                         "type": "string",
                                         "value": "Remove Windows IPsec Quarantine"
                                     }
@@ -1988,7 +1988,7 @@
                             "inputs": {
                                 "variables": [
                                     {
-                                        "name": "action results",
+                                        "name": "knownActionResults",
                                         "type": "array"
                                     }
                                 ]
@@ -2004,7 +2004,7 @@
                             "inputs": {
                                 "variables": [
                                     {
-                                        "name": "all computers id",
+                                        "name": "allComputersGroupId",
                                         "type": "string",
                                         "value": "@{body('Get_the_\"All_Computers\"_group')?['data']?['id']}"
                                     }
@@ -2038,7 +2038,7 @@
                             "inputs": {
                                 "variables": [
                                     {
-                                        "name": "issued actions",
+                                        "name": "issuedActions",
                                         "type": "array"
                                     }
                                 ]
@@ -2054,7 +2054,7 @@
                             "inputs": {
                                 "variables": [
                                     {
-                                        "name": "macos endpoint filters",
+                                        "name": "macOsEndpointFilters",
                                         "type": "array"
                                     }
                                 ]
@@ -2070,7 +2070,7 @@
                             "inputs": {
                                 "variables": [
                                     {
-                                        "name": "package parameters",
+                                        "name": "packageParameters",
                                         "type": "array"
                                     }
                                 ]
@@ -2087,7 +2087,7 @@
                             "inputs": {
                                 "variables": [
                                     {
-                                        "name": "unknown action results",
+                                        "name": "unknownActionResults",
                                         "type": "array"
                                     }
                                 ]
@@ -2130,8 +2130,8 @@
                                             "type": "Http",
                                             "inputs": {
                                                 "body": {
-                                                    "query": "@variables('api gateway query')",
-                                                    "variables": "@json(variables('api gateway query variables'))"
+                                                    "query": "@variables('apiQuery')",
+                                                    "variables": "@json(variables('apiVariables'))"
                                                 },
                                                 "headers": {
                                                     "Content-Type": "application/json",
@@ -2215,8 +2215,8 @@
                                             "runAfter": {},
                                             "type": "SetVariable",
                                             "inputs": {
-                                                "name": "api gateway query variables",
-                                                "value": "{\n  \"source\": @{variables('tanium endpoint source')},\n  \"endCursor\": \"@{variables('cursor')}\"\n}"
+                                                "name": "apiVariables",
+                                                "value": "{\n  \"source\": @{variables('endpointSource')},\n  \"endCursor\": \"@{variables('cursor')}\"\n}"
                                             }
                                         }
                                     },
@@ -2254,7 +2254,7 @@
                             },
                             "type": "ParseJson",
                             "inputs": {
-                                "content": "@variables('API Gateway Response')",
+                                "content": "@variables('apiResponse')",
                                 "schema": {
                                     "properties": {
                                         "data": {
@@ -2336,8 +2336,8 @@
                             "type": "Http",
                             "inputs": {
                                 "body": {
-                                    "query": "@variables('api gateway query')",
-                                    "variables": "@json(variables('api gateway query variables'))"
+                                    "query": "@variables('apiQuery')",
+                                    "variables": "@json(variables('apiVariables'))"
                                 },
                                 "headers": {
                                     "Content-Type": "application/json",
@@ -2362,7 +2362,7 @@
                             },
                             "type": "Select",
                             "inputs": {
-                                "from": "@variables('issued actions')",
+                                "from": "@variables('issuedActions')",
                                 "select": "@int(item()?['expire_seconds'])"
                             }
                         },
@@ -2377,8 +2377,8 @@
                                     "type": "Http",
                                     "inputs": {
                                         "body": {
-                                            "query": "@variables('api gateway query')",
-                                            "variables": "@json(variables('api gateway query variables'))"
+                                            "query": "@variables('apiQuery')",
+                                            "variables": "@json(variables('apiVariables'))"
                                         },
                                         "headers": {
                                             "Content-Type": "application/json",
@@ -2400,7 +2400,7 @@
                                     "runAfter": {},
                                     "type": "SetVariable",
                                     "inputs": {
-                                        "name": "tanium endpoint source",
+                                        "name": "endpointSource",
                                         "value": {
                                             "ts": {
                                                 "stableWaitTime": 30
@@ -2416,7 +2416,7 @@
                                     },
                                     "type": "SetVariable",
                                     "inputs": {
-                                        "name": "API Gateway Response",
+                                        "name": "apiResponse",
                                         "value": "@body('Requery_the_API_Gateway')"
                                     }
                                 },
@@ -2428,8 +2428,8 @@
                                     },
                                     "type": "SetVariable",
                                     "inputs": {
-                                        "name": "api gateway query variables",
-                                        "value": "{\n  \"source\": @{variables('Tanium Endpoint Source')},\n  \"incidentHosts\": {\n    \"any\": true,\n    \"filters\": @{variables('endpoint filters')}\n  }\n}"
+                                        "name": "apiVariables",
+                                        "value": "{\n  \"source\": @{variables('endpointSource')},\n  \"incidentHosts\": {\n    \"any\": true,\n    \"filters\": @{variables('endpointFilters')}\n  }\n}"
                                     }
                                 }
                             },

--- a/Solutions/Tanium/Playbooks/Tanium-UnquarantineHosts/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-UnquarantineHosts/azuredeploy.json
@@ -142,27 +142,6 @@
                         }
                     },
                     "actions": {
-                        "Add_comment_to_incident_-_hosts_that_will_be_targeted": {
-                            "runAfter": {
-                                "Create_HTML_table_of_matched_endpoints": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "ApiConnection",
-                            "inputs": {
-                                "body": {
-                                    "incidentArmId": "@triggerBody()?['object']?['id']",
-                                    "message": "<p>Preparing to issue quarantine actions targeting these endpoints associated with this incident<br>\n@{body('Create_HTML_table_of_matched_endpoints')}</p>"
-                                },
-                                "host": {
-                                    "connection": {
-                                        "name": "@parameters('$connections')['azuresentinel']['connectionId']"
-                                    }
-                                },
-                                "method": "post",
-                                "path": "/Incidents/Comment"
-                            }
-                        },
                         "Exit_early_if_no_unquarantine_actions_were_successfully_issued": {
                             "actions": {
                                 "Terminate_-_no_actions_were_successfully_issued": {
@@ -244,400 +223,6 @@
                                 }
                             }
                         },
-                        "Collect_action_results_for_each_issued_action": {
-                            "foreach": "@variables('issuedActions')",
-                            "actions": {
-                                "Get_action_result": {
-                                    "type": "Http",
-                                    "inputs": {
-                                        "headers": {
-                                            "Content-Type": "application/json",
-                                            "session": "@parameters('TaniumApiToken')"
-                                        },
-                                        "method": "GET",
-                                        "uri": "@{concat(parameters('TaniumActionResultDataUrlFragment'), items('Collect_action_results_for_each_issued_action')?['id'])}"
-                                    },
-                                    "runtimeConfiguration": {
-                                        "secureData": {
-                                            "properties": [
-                                                "inputs"
-                                            ]
-                                        }
-                                    }
-                                },
-                                "If_action_result_could_be_determined": {
-                                    "actions": {
-                                        "For_each_action_result_set": {
-                                            "foreach": "@body('Parse_action_result')",
-                                            "actions": {
-                                                "Append_to_action_results": {
-                                                    "type": "AppendToArrayVariable",
-                                                    "inputs": {
-                                                        "name": "knownActionResults",
-                                                        "value": "@item()"
-                                                    }
-                                                }
-                                            },
-                                            "type": "Foreach"
-                                        }
-                                    },
-                                    "runAfter": {
-                                        "Parse_action_result": [
-                                            "Succeeded"
-                                        ]
-                                    },
-                                    "else": {
-                                        "actions": {
-                                            "Append_to_unknown_action_results": {
-                                                "runAfter": {
-                                                    "Compose_unknown_action_result": [
-                                                        "Succeeded"
-                                                    ]
-                                                },
-                                                "type": "AppendToArrayVariable",
-                                                "inputs": {
-                                                    "name": "unknownActionResults",
-                                                    "value": "@outputs('Compose_unknown_action_result')"
-                                                }
-                                            },
-                                            "Compose_unknown_action_result": {
-                                                "type": "Compose",
-                                                "inputs": {
-                                                    "action id": "@item()?['id']",
-                                                    "status": "Completed with unknown result"
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "expression": {
-                                        "and": [
-                                            {
-                                                "greater": [
-                                                    "@length(outputs('Parse_action_result')['body'])",
-                                                    0
-                                                ]
-                                            }
-                                        ]
-                                    },
-                                    "type": "If"
-                                },
-                                "Parse_action_result": {
-                                    "runAfter": {
-                                        "Parse_current_issued_action": [
-                                            "Succeeded"
-                                        ]
-                                    },
-                                    "type": "JavaScriptCode",
-                                    "inputs": {
-                                        "code": "var action_results = workflowContext.actions.Get_action_result.outputs.body.data;\r\nvar action_id = workflowContext.actions.Parse_current_issued_action.outputs.body.id;\r\nvar columns = action_results.result_sets[0].columns.map(c => c.name);\r\nvar robjects = [];\r\n\r\naction_results.result_sets.forEach(function(rs) {\r\n\trs.rows.forEach(function(row) {\r\n\t\tlet robject = {'action id': action_id};\r\n\t\tcolumns.forEach(function(c, i) {\r\n\t\t\trobject[c] = row.data[i][0].text;\r\n\t\t});\r\n\t\trobjects.push(robject);\r\n\t});\r\n});\r\n\r\nreturn robjects;"
-                                    }
-                                },
-                                "Parse_current_issued_action": {
-                                    "runAfter": {
-                                        "Get_action_result": [
-                                            "Succeeded"
-                                        ]
-                                    },
-                                    "type": "ParseJson",
-                                    "inputs": {
-                                        "content": "@items('Collect_action_results_for_each_issued_action')",
-                                        "schema": {
-                                            "properties": {
-                                                "action_group": {
-                                                    "properties": {
-                                                        "id": {
-                                                            "type": "integer"
-                                                        },
-                                                        "name": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "type": "object"
-                                                },
-                                                "approver": {
-                                                    "properties": {
-                                                        "id": {
-                                                            "type": "integer"
-                                                        },
-                                                        "name": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "type": "object"
-                                                },
-                                                "comment": {
-                                                    "type": "string"
-                                                },
-                                                "creation_time": {
-                                                    "type": "string"
-                                                },
-                                                "distribute_seconds": {
-                                                    "type": "integer"
-                                                },
-                                                "expiration_time": {
-                                                    "type": "string"
-                                                },
-                                                "expire_seconds": {
-                                                    "type": "integer"
-                                                },
-                                                "history_saved_question": {
-                                                    "properties": {
-                                                        "id": {
-                                                            "type": "integer"
-                                                        }
-                                                    },
-                                                    "type": "object"
-                                                },
-                                                "id": {
-                                                    "type": "integer"
-                                                },
-                                                "name": {
-                                                    "type": "string"
-                                                },
-                                                "package_spec": {
-                                                    "properties": {
-                                                        "available_time": {
-                                                            "type": "string"
-                                                        },
-                                                        "command": {
-                                                            "type": "string"
-                                                        },
-                                                        "command_timeout": {
-                                                            "type": "integer"
-                                                        },
-                                                        "content_set": {
-                                                            "properties": {
-                                                                "id": {
-                                                                    "type": "integer"
-                                                                },
-                                                                "name": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "type": "object"
-                                                        },
-                                                        "creation_time": {
-                                                            "type": "string"
-                                                        },
-                                                        "deleted_flag": {
-                                                            "type": "boolean"
-                                                        },
-                                                        "display_name": {
-                                                            "type": "string"
-                                                        },
-                                                        "expire_seconds": {
-                                                            "type": "integer"
-                                                        },
-                                                        "hidden_flag": {
-                                                            "type": "boolean"
-                                                        },
-                                                        "id": {
-                                                            "type": "integer"
-                                                        },
-                                                        "last_modified_by": {
-                                                            "type": "string"
-                                                        },
-                                                        "last_update": {
-                                                            "type": "string"
-                                                        },
-                                                        "mod_user": {
-                                                            "properties": {
-                                                                "display_name": {
-                                                                    "type": "string"
-                                                                },
-                                                                "domain": {
-                                                                    "type": "string"
-                                                                },
-                                                                "id": {
-                                                                    "type": "integer"
-                                                                },
-                                                                "name": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "type": "object"
-                                                        },
-                                                        "modification_time": {
-                                                            "type": "string"
-                                                        },
-                                                        "name": {
-                                                            "type": "string"
-                                                        },
-                                                        "parameter_definition": {
-                                                            "type": "string"
-                                                        },
-                                                        "process_group_flag": {
-                                                            "type": "boolean"
-                                                        },
-                                                        "skip_lock_flag": {
-                                                            "type": "boolean"
-                                                        },
-                                                        "source_hash": {
-                                                            "type": "string"
-                                                        },
-                                                        "verify_expire_seconds": {
-                                                            "type": "integer"
-                                                        },
-                                                        "verify_group": {
-                                                            "properties": {
-                                                                "id": {
-                                                                    "type": "integer"
-                                                                }
-                                                            },
-                                                            "type": "object"
-                                                        },
-                                                        "verify_group_id": {
-                                                            "type": "integer"
-                                                        }
-                                                    },
-                                                    "type": "object"
-                                                },
-                                                "saved_action": {
-                                                    "properties": {
-                                                        "id": {
-                                                            "type": "integer"
-                                                        }
-                                                    },
-                                                    "type": "object"
-                                                },
-                                                "skip_lock_flag": {
-                                                    "type": "boolean"
-                                                },
-                                                "start_time": {
-                                                    "type": "string"
-                                                },
-                                                "status": {
-                                                    "type": "string"
-                                                },
-                                                "stopped_flag": {
-                                                    "type": "boolean"
-                                                },
-                                                "target_group": {
-                                                    "properties": {
-                                                        "id": {
-                                                            "type": "integer"
-                                                        },
-                                                        "name": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "type": "object"
-                                                },
-                                                "user": {
-                                                    "properties": {
-                                                        "creation_time": {
-                                                            "type": "string"
-                                                        },
-                                                        "deleted_flag": {
-                                                            "type": "boolean"
-                                                        },
-                                                        "display_name": {
-                                                            "type": "string"
-                                                        },
-                                                        "domain": {
-                                                            "type": "string"
-                                                        },
-                                                        "effective_group_id": {
-                                                            "type": "integer"
-                                                        },
-                                                        "external_flag": {
-                                                            "type": "integer"
-                                                        },
-                                                        "group_id": {
-                                                            "type": "integer"
-                                                        },
-                                                        "id": {
-                                                            "type": "integer"
-                                                        },
-                                                        "last_login": {
-                                                            "type": "string"
-                                                        },
-                                                        "locked_out": {
-                                                            "type": "integer"
-                                                        },
-                                                        "mod_user": {
-                                                            "properties": {
-                                                                "display_name": {
-                                                                    "type": "string"
-                                                                },
-                                                                "domain": {
-                                                                    "type": "string"
-                                                                },
-                                                                "id": {
-                                                                    "type": "integer"
-                                                                },
-                                                                "name": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "type": "object"
-                                                        },
-                                                        "modification_time": {
-                                                            "type": "string"
-                                                        },
-                                                        "name": {
-                                                            "type": "string"
-                                                        },
-                                                        "previous_login": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "type": "object"
-                                                }
-                                            },
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            },
-                            "runAfter": {
-                                "Wait_for_the_max_expire_seconds_from_the_issued_actions": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "Foreach",
-                            "runtimeConfiguration": {
-                                "concurrency": {
-                                    "repetitions": 1
-                                }
-                            }
-                        },
-                        "Create_HTML_table_of_action_results": {
-                            "runAfter": {
-                                "Collect_action_results_for_each_issued_action": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "Table",
-                            "inputs": {
-                                "format": "HTML",
-                                "from": "@variables('knownActionResults')"
-                            }
-                        },
-                        "Create_HTML_table_of_matched_endpoints": {
-                            "runAfter": {
-                                "Flatten_API_Gateway_endpoints": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "Table",
-                            "inputs": {
-                                "format": "HTML",
-                                "from": "@body('Flatten_API_Gateway_endpoints')"
-                            }
-                        },
-                        "Create_HTML_table_of_unknown_action_results": {
-                            "runAfter": {
-                                "Collect_action_results_for_each_issued_action": [
-                                    "SUCCEEDED"
-                                ]
-                            },
-                            "type": "Table",
-                            "inputs": {
-                                "format": "HTML",
-                                "from": "@variables('unknownActionResults')"
-                            }
-                        },
                         "Get_Hosts_From_Incident": {
                             "runAfter": {},
                             "type": "ApiConnection",
@@ -701,137 +286,6 @@
                             "else": {
                                 "actions": {}
                             }
-                        },
-                        "Flatten_API_Gateway_endpoints": {
-                            "runAfter": {
-                                "Parse_endpoints_array": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "JavaScriptCode",
-                            "inputs": {
-                                "code": "var e = workflowContext.actions.Parse_endpoints_array.outputs.body;\r\n\r\nfunction sensorReadings(r) {\r\n\treturn r.columns.map(c => {\r\n\t\tif (c.sensor && c.sensor.name) {\r\n\t\t\treturn { name: [c.sensor.name, c.name].join(' - '), value: c.values.join(' ') };\r\n\t\t} else {\r\n\t\t\treturn { name: c.name, value: c.values.join(' ') };\r\n\t\t}\r\n\t});\r\n}\r\n\r\nfunction flatten(obj, pk = '') {\r\n\tif (pk !== '') pk += ' ';\r\n\tlet flat = {};\r\n\tObject.keys(obj).forEach((key) => {\r\n\t\tif (key === 'sensorReadings') {\r\n\t\t\tsensorReadings(obj[key]).forEach((r) => {\r\n\t\t\t\tflat[r.name] = r.value;\r\n\t\t\t});\r\n\t\t} else {\r\n\t\t\tif (typeof obj[key] === 'object' && obj[key] !== null) {\r\n\t\t\t\tObject.assign(flat, flatten(obj[key], pk + key));\r\n\t\t\t} else {\r\n\t\t\t\tflat[pk + key] = obj[key];\r\n\t\t\t}\r\n\t\t}\r\n\t});\r\n\treturn flat;\r\n}\r\n\r\nreturn e.map(function(e) { return flatten(e.node); });"
-                            }
-                        },
-                        "For_each_host_on_the_incident": {
-                            "foreach": "@variables('endpoints')",
-                            "actions": {
-                                "Compose_endpoint_filter_for_packages": {
-                                    "runAfter": {
-                                        "Parse_endpoint_JSON_data": [
-                                            "Succeeded"
-                                        ]
-                                    },
-                                    "type": "Compose",
-                                    "inputs": {
-                                        "and_flag": true,
-                                        "filters": [
-                                            {
-                                                "operator": "Equal",
-                                                "sensor": {
-                                                    "name": "Computer Name"
-                                                },
-                                                "value": "@body('Parse_endpoint_JSON_data')?['node']?['name']"
-                                            },
-                                            {
-                                                "operator": "RegexMatch",
-                                                "sensor": {
-                                                    "name": "IP Address"
-                                                },
-                                                "value": "@body('Parse_endpoint_JSON_data')?['node']?['ipAddress']"
-                                            }
-                                        ]
-                                    },
-                                    "description": "Compose the filter for the current incident host to be used to get the unquarantine package"
-                                },
-                                "Parse_endpoint_JSON_data": {
-                                    "type": "ParseJson",
-                                    "inputs": {
-                                        "content": "@items('For_each_host_on_the_incident')",
-                                        "schema": {
-                                            "properties": {
-                                                "node": {
-                                                    "properties": {
-                                                        "ipAddress": {
-                                                            "type": "string"
-                                                        },
-                                                        "name": {
-                                                            "type": "string"
-                                                        },
-                                                        "os": {
-                                                            "properties": {
-                                                                "platform": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "type": "object"
-                                                        }
-                                                    },
-                                                    "type": "object"
-                                                }
-                                            },
-                                            "type": "object"
-                                        }
-                                    }
-                                },
-                                "Switch": {
-                                    "runAfter": {
-                                        "Compose_endpoint_filter_for_packages": [
-                                            "Succeeded"
-                                        ]
-                                    },
-                                    "cases": {
-                                        "Linux": {
-                                            "case": "Linux",
-                                            "actions": {
-                                                "Append_to_Linux_endpoint_filters": {
-                                                    "type": "AppendToArrayVariable",
-                                                    "inputs": {
-                                                        "name": "linuxEndpointFilters",
-                                                        "value": "@outputs('Compose_endpoint_filter_for_packages')"
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "Mac": {
-                                            "case": "Mac",
-                                            "actions": {
-                                                "Append_to_macOS_endpoint_filters": {
-                                                    "type": "AppendToArrayVariable",
-                                                    "inputs": {
-                                                        "name": "macOsEndpointFilters",
-                                                        "value": "@outputs('Compose_endpoint_filter_for_packages')"
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "Windows": {
-                                            "case": "Windows",
-                                            "actions": {
-                                                "Append_to_Windows_endpoint_filters": {
-                                                    "type": "AppendToArrayVariable",
-                                                    "inputs": {
-                                                        "name": "windowsEndpointFilters",
-                                                        "value": "@outputs('Compose_endpoint_filter_for_packages')"
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "default": {
-                                        "actions": {}
-                                    },
-                                    "expression": "@body('Parse_endpoint_JSON_data')?['node']?['os']?['platform']",
-                                    "type": "Switch"
-                                }
-                            },
-                            "runAfter": {
-                                "Set_allComputersGroupId": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "Foreach",
-                            "description": "Loop through each host that was on the incident and where Tanium had data about the host"
                         },
                         "Build_Endpoint_Filter_from_Hosts": {
                             "inputs": {
@@ -1133,7 +587,7 @@
                                 }
                             },
                             "runAfter": {
-                                "For_each_host_on_the_incident": [
+                                "Generate_the_endpoints_filters_for_each_OS_package": [
                                     "Succeeded"
                                 ]
                             },
@@ -1388,7 +842,7 @@
                                 }
                             },
                             "runAfter": {
-                                "For_each_host_on_the_incident": [
+                                "Generate_the_endpoints_filters_for_each_OS_package": [
                                     "Succeeded"
                                 ]
                             },
@@ -1406,106 +860,6 @@
                             "else": {
                                 "actions": {}
                             }
-                        },
-                        "If_action_results_and_unknown_action_results": {
-                            "actions": {
-                                "Add_comment_to_incident_-_known_and_unknown_action_results": {
-                                    "type": "ApiConnection",
-                                    "inputs": {
-                                        "body": {
-                                            "incidentArmId": "@triggerBody()?['object']?['id']",
-                                            "message": "<p>QUARANTINE ACTION RESULTS<br>\n@{body('Create_HTML_table_of_action_results')}<br>\n<br>\n@{body('Create_HTML_table_of_unknown_action_results')}</p>"
-                                        },
-                                        "host": {
-                                            "connection": {
-                                                "name": "@parameters('$connections')['azuresentinel']['connectionId']"
-                                            }
-                                        },
-                                        "method": "post",
-                                        "path": "/Incidents/Comment"
-                                    }
-                                }
-                            },
-                            "runAfter": {
-                                "Create_HTML_table_of_unknown_action_results": [
-                                    "Succeeded"
-                                ],
-                                "Create_HTML_table_of_action_results": [
-                                    "SUCCEEDED"
-                                ]
-                            },
-                            "else": {
-                                "actions": {
-                                    "If_action_results": {
-                                        "actions": {
-                                            "Add_comment_to_incident_-_known_action_results": {
-                                                "type": "ApiConnection",
-                                                "inputs": {
-                                                    "body": {
-                                                        "incidentArmId": "@triggerBody()?['object']?['id']",
-                                                        "message": "<p>QUARANTINE ACTION RESULTS<br>\n@{body('Create_HTML_table_of_action_results')}</p>"
-                                                    },
-                                                    "host": {
-                                                        "connection": {
-                                                            "name": "@parameters('$connections')['azuresentinel']['connectionId']"
-                                                        }
-                                                    },
-                                                    "method": "post",
-                                                    "path": "/Incidents/Comment"
-                                                }
-                                            }
-                                        },
-                                        "expression": {
-                                            "and": [
-                                                {
-                                                    "greater": [
-                                                        "@length(variables('knownActionResults'))",
-                                                        0
-                                                    ]
-                                                }
-                                            ]
-                                        },
-                                        "type": "If",
-                                        "else": {
-                                            "actions": {
-                                                "Add_comment_to_incident_-_unknown_action_results": {
-                                                    "type": "ApiConnection",
-                                                    "inputs": {
-                                                        "body": {
-                                                            "incidentArmId": "@triggerBody()?['object']?['id']",
-                                                            "message": "<p>QUARANTINE ACTION RESULTS<br>\n@{body('Create_HTML_table_of_unknown_action_results')}</p>"
-                                                        },
-                                                        "host": {
-                                                            "connection": {
-                                                                "name": "@parameters('$connections')['azuresentinel']['connectionId']"
-                                                            }
-                                                        },
-                                                        "method": "post",
-                                                        "path": "/Incidents/Comment"
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            "expression": {
-                                "and": [
-                                    {
-                                        "greater": [
-                                            "@length(variables('knownActionResults'))",
-                                            0
-                                        ]
-                                    },
-                                    {
-                                        "greater": [
-                                            "@length(variables('unknownActionResults'))",
-                                            0
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "If"
                         },
                         "Apply_unquarantine_action_to_macOS_endpoints": {
                             "actions": {
@@ -1743,7 +1097,7 @@
                                 }
                             },
                             "runAfter": {
-                                "For_each_host_on_the_incident": [
+                                "Generate_the_endpoints_filters_for_each_OS_package": [
                                     "Succeeded"
                                 ]
                             },
@@ -1815,56 +1169,6 @@
                                 ]
                             }
                         },
-                        "Exit_early_If_Tanium_Has_No_Data_for_Incident": {
-                            "actions": {
-                                "Add_comment__-_no_data_in_Tanium": {
-                                    "type": "ApiConnection",
-                                    "inputs": {
-                                        "body": {
-                                            "incidentArmId": "@triggerBody()?['object']?['id']",
-                                            "message": "<p>No data found in Tanium for hosts.</p>"
-                                        },
-                                        "host": {
-                                            "connection": {
-                                                "name": "@parameters('$connections')['azuresentinel']['connectionId']"
-                                            }
-                                        },
-                                        "method": "post",
-                                        "path": "/Incidents/Comment"
-                                    }
-                                },
-                                "Exit_early__-_no_data_in_Tanium": {
-                                    "runAfter": {
-                                        "Add_comment__-_no_data_in_Tanium": [
-                                            "Succeeded"
-                                        ]
-                                    },
-                                    "type": "Terminate",
-                                    "inputs": {
-                                        "runStatus": "Succeeded"
-                                    }
-                                }
-                            },
-                            "runAfter": {
-                                "Parse_API_response": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "expression": {
-                                "and": [
-                                    {
-                                        "equals": [
-                                            "@body('Parse_API_response')?['data']?['endpoints']?['pageInfo']?['endCursor']",
-                                            "@null"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "If",
-                            "else": {
-                                "actions": {}
-                            }
-                        },
                         "Initialize_Endpoint_Filter": {
                             "runAfter": {
                                 "Exit_early_if_incident_has_no_hosts": [
@@ -1883,7 +1187,7 @@
                         },
                         "Initialize_the_name_of_the_Linux_unquarantine_package": {
                             "runAfter": {
-                                "Add_comment_to_incident_-_hosts_that_will_be_targeted": [
+                                "Get_information_about_incident_hosts_from_Tanium": [
                                     "Succeeded"
                                 ]
                             },
@@ -1900,7 +1204,7 @@
                         },
                         "Initialize_the_name_of_the_MacOS_unquarantine_package": {
                             "runAfter": {
-                                "Add_comment_to_incident_-_hosts_that_will_be_targeted": [
+                                "Get_information_about_incident_hosts_from_Tanium": [
                                     "Succeeded"
                                 ]
                             },
@@ -1936,7 +1240,7 @@
                         },
                         "Initialize_the_name_of_the_Windows_unquarantine_package": {
                             "runAfter": {
-                                "Add_comment_to_incident_-_hosts_that_will_be_targeted": [
+                                "Get_information_about_incident_hosts_from_Tanium": [
                                     "Succeeded"
                                 ]
                             },
@@ -1953,7 +1257,7 @@
                         },
                         "Initialize_list_of_issued_actions": {
                             "runAfter": {
-                                "Add_comment_to_incident_-_hosts_that_will_be_targeted": [
+                                "Get_information_about_incident_hosts_from_Tanium": [
                                     "Succeeded"
                                 ]
                             },
@@ -1969,7 +1273,7 @@
                         },
                         "Initialize_unquarantine_package_parameters": {
                             "runAfter": {
-                                "Add_comment_to_incident_-_hosts_that_will_be_targeted": [
+                                "Get_information_about_incident_hosts_from_Tanium": [
                                     "Succeeded"
                                 ]
                             },
@@ -1986,7 +1290,7 @@
                         },
                         "Initialize_list_of_unknown_action_results": {
                             "runAfter": {
-                                "Add_comment_to_incident_-_hosts_that_will_be_targeted": [
+                                "Get_information_about_incident_hosts_from_Tanium": [
                                     "Succeeded"
                                 ]
                             },
@@ -1998,395 +1302,6 @@
                                         "type": "array"
                                     }
                                 ]
-                            }
-                        },
-                        "Loop_Paginated_Response_if_has_multiple_pages": {
-                            "actions": {
-                                "Until_no_more_pages": {
-                                    "actions": {
-                                        "For_each_endpoint_in_paginated_API_Gateway_response": {
-                                            "foreach": "@body('Parse_page')?['data']?['endpoints']?['edges']",
-                                            "actions": {
-                                                "Append_endpoint_to_endpoints": {
-                                                    "type": "AppendToArrayVariable",
-                                                    "inputs": {
-                                                        "name": "endpoints",
-                                                        "value": "@items('For_each_endpoint_in_paginated_API_Gateway_response')"
-                                                    }
-                                                }
-                                            },
-                                            "runAfter": {
-                                                "Update_cursor_to_next_page": [
-                                                    "Succeeded"
-                                                ]
-                                            },
-                                            "type": "Foreach",
-                                            "runtimeConfiguration": {
-                                                "concurrency": {
-                                                    "repetitions": 1
-                                                }
-                                            }
-                                        },
-                                        "Get_next_page": {
-                                            "runAfter": {
-                                                "Update_cursor_for_next_page": [
-                                                    "Succeeded"
-                                                ]
-                                            },
-                                            "type": "Http",
-                                            "inputs": {
-                                                "body": {
-                                                    "query": "@variables('apiQuery')",
-                                                    "variables": "@json(variables('apiVariables'))"
-                                                },
-                                                "headers": {
-                                                    "Content-Type": "application/json",
-                                                    "session": "@parameters('TaniumApiToken')"
-                                                },
-                                                "method": "POST",
-                                                "uri": "@parameters('TaniumApiGatewayApi')"
-                                            },
-                                            "runtimeConfiguration": {
-                                                "secureData": {
-                                                    "properties": [
-                                                        "inputs"
-                                                    ]
-                                                }
-                                            }
-                                        },
-                                        "Parse_page": {
-                                            "runAfter": {
-                                                "Get_next_page": [
-                                                    "Succeeded"
-                                                ]
-                                            },
-                                            "type": "ParseJson",
-                                            "inputs": {
-                                                "content": "@body('Get_next_page')",
-                                                "schema": {
-                                                    "properties": {
-                                                        "data": {
-                                                            "properties": {
-                                                                "endpoints": {
-                                                                    "properties": {
-                                                                        "edges": {
-                                                                            "items": {
-                                                                                "properties": {
-                                                                                    "node": {
-                                                                                        "type": "object"
-                                                                                    }
-                                                                                },
-                                                                                "required": [
-                                                                                    "node"
-                                                                                ],
-                                                                                "type": "object"
-                                                                            },
-                                                                            "type": "array"
-                                                                        },
-                                                                        "pageInfo": {
-                                                                            "properties": {
-                                                                                "endCursor": {
-                                                                                    "type": [
-                                                                                        "string",
-                                                                                        "null"
-                                                                                    ]
-                                                                                },
-                                                                                "hasNextPage": {
-                                                                                    "type": "boolean"
-                                                                                }
-                                                                            },
-                                                                            "type": "object"
-                                                                        }
-                                                                    },
-                                                                    "type": "object"
-                                                                }
-                                                            },
-                                                            "type": "object"
-                                                        }
-                                                    },
-                                                    "type": "object"
-                                                }
-                                            }
-                                        },
-                                        "Update_cursor_to_next_page": {
-                                            "runAfter": {
-                                                "Parse_page": [
-                                                    "Succeeded"
-                                                ]
-                                            },
-                                            "type": "SetVariable",
-                                            "inputs": {
-                                                "name": "cursor",
-                                                "value": "@body('Parse_page')?['data']?['endpoints']?['pageInfo']?['endCursor']"
-                                            }
-                                        },
-                                        "Update_cursor_for_next_page": {
-                                            "type": "SetVariable",
-                                            "inputs": {
-                                                "name": "apiQuery",
-                                                "value": "{\n  \"source\": @{variables('endpointSource')},\n  \"endCursor\": \"@{variables('cursor')}\"\n}"
-                                            }
-                                        }
-                                    },
-                                    "expression": "@equals(body('Parse_page')?['data']?['endpoints']?['pageInfo']?['hasNextPage'],false)",
-                                    "limit": {
-                                        "count": 60,
-                                        "timeout": "PT1H"
-                                    },
-                                    "type": "Until"
-                                }
-                            },
-                            "runAfter": {
-                                "Set_cursor": [
-                                    "Succeeded"
-                                ],
-                                "Set_endpoints_list": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "expression": {
-                                "and": [
-                                    {
-                                        "equals": [
-                                            "@body('Parse_API_response')?['data']?['endpoints']?['pageInfo']?['hasNextPage']",
-                                            "@true"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "If",
-                            "else": {
-                                "actions": {}
-                            }
-                        },
-                        "Parse_API_response": {
-                            "runAfter": {
-                                "Switch_to_TS_from_TDS_if_needed": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "ParseJson",
-                            "inputs": {
-                                "content": "@variables('apiResponse')",
-                                "schema": {
-                                    "properties": {
-                                        "data": {
-                                            "properties": {
-                                                "endpoints": {
-                                                    "properties": {
-                                                        "edges": {
-                                                            "items": {
-                                                                "properties": {
-                                                                    "node": {
-                                                                        "properties": {},
-                                                                        "type": "object"
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "node"
-                                                                ],
-                                                                "type": "object"
-                                                            },
-                                                            "type": "array"
-                                                        },
-                                                        "pageInfo": {
-                                                            "properties": {
-                                                                "endCursor": {
-                                                                    "type": "string"
-                                                                },
-                                                                "hasNextPage": {
-                                                                    "type": "boolean"
-                                                                }
-                                                            },
-                                                            "type": "object"
-                                                        }
-                                                    },
-                                                    "type": "object"
-                                                }
-                                            },
-                                            "type": "object"
-                                        },
-                                        "errors": {
-                                            "items": {
-                                                "properties": {
-                                                    "message": {
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "message"
-                                                ],
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        }
-                                    },
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "Parse_endpoints_array": {
-                            "runAfter": {
-                                "Loop_Paginated_Response_if_has_multiple_pages": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "ParseJson",
-                            "inputs": {
-                                "content": "@variables('endpoints')",
-                                "schema": {
-                                    "type": "array"
-                                }
-                            },
-                            "description": "We need an action's output to use in the JavaScript code since it can't read from a variable"
-                        },
-                        "Get_General_Host_Info": {
-                            "runAfter": {
-                                "Initialize_API_Variables": [
-                                    "Succeeded"
-                                ],
-                                "Initialize_API_Query": [
-                                    "Succeeded"
-                                ],
-                                "Initialize_cursor": [
-                                    "Succeeded"
-                                ],
-                                "Initialize_endpoints_array": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "Http",
-                            "inputs": {
-                                "body": {
-                                    "query": "@variables('apiQuery')",
-                                    "variables": "@json(variables('apiVariables'))"
-                                },
-                                "headers": {
-                                    "Content-Type": "application/json",
-                                    "session": "@parameters('TaniumApiToken')"
-                                },
-                                "method": "POST",
-                                "uri": "@parameters('TaniumApiGatewayApi')"
-                            },
-                            "runtimeConfiguration": {
-                                "secureData": {
-                                    "properties": [
-                                        "inputs"
-                                    ]
-                                }
-                            },
-                            "description": "Get information about the incident hosts from Tanium."
-                        },
-                        "Select_expire_seconds": {
-                            "runAfter": {
-                                "Initialize_action_results": [
-                                    "SUCCEEDED"
-                                ]
-                            },
-                            "type": "Select",
-                            "inputs": {
-                                "from": "@variables('issuedActions')",
-                                "select": "@int(item()?['expire_seconds'])"
-                            }
-                        },
-                        "Switch_to_TS_from_TDS_if_needed": {
-                            "actions": {
-                                "Requery_the_API_Gateway": {
-                                    "runAfter": {
-                                        "Update_API_Query_variables_to_get_new_source": [
-                                            "Succeeded"
-                                        ]
-                                    },
-                                    "type": "Http",
-                                    "inputs": {
-                                        "body": {
-                                            "query": "@variables('apiQuery')",
-                                            "variables": "@json(variables('apiVariables'))"
-                                        },
-                                        "headers": {
-                                            "Content-Type": "application/json",
-                                            "session": "@parameters('TaniumApiToken')"
-                                        },
-                                        "method": "POST",
-                                        "uri": "@parameters('TaniumApiGatewayApi')"
-                                    },
-                                    "runtimeConfiguration": {
-                                        "secureData": {
-                                            "properties": [
-                                                "inputs"
-                                            ]
-                                        }
-                                    }
-                                },
-                                "Change_Endpoint_Source_to_TS": {
-                                    "type": "SetVariable",
-                                    "inputs": {
-                                        "name": "endpointSource",
-                                        "value": {
-                                            "ts": {
-                                                "stableWaitTime": 30
-                                            }
-                                        }
-                                    }
-                                },
-                                "Update_API_Gateway_Response": {
-                                    "runAfter": {
-                                        "Requery_the_API_Gateway": [
-                                            "Succeeded"
-                                        ]
-                                    },
-                                    "type": "SetVariable",
-                                    "inputs": {
-                                        "name": "apiResponse",
-                                        "value": "@body('Requery_the_API_Gateway')"
-                                    }
-                                },
-                                "Update_API_Query_variables_to_get_new_source": {
-                                    "runAfter": {
-                                        "Change_Endpoint_Source_to_TS": [
-                                            "Succeeded"
-                                        ]
-                                    },
-                                    "type": "SetVariable",
-                                    "inputs": {
-                                        "name": "apiVariables",
-                                        "value": "{\n  \"source\": @{variables('endpointSource')},\n  \"incidentHosts\": {\n    \"any\": true,\n    \"filters\": @{variables('endpointFilters')}\n  }\n}"
-                                    }
-                                }
-                            },
-                            "runAfter": {
-                                "Set_apiResponse": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "expression": {
-                                "and": [
-                                    {
-                                        "contains": [
-                                            "@string(body('Get_General_Host_Info'))",
-                                            "must refer to an existing sensor"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "If",
-                            "else": {
-                                "actions": {}
-                            },
-                            "description": "Switch from asking the Tanium Server for information to using the Tanium Data Service."
-                        },
-                        "Wait_for_the_max_expire_seconds_from_the_issued_actions": {
-                            "runAfter": {
-                                "Select_expire_seconds": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "Wait",
-                            "inputs": {
-                                "interval": {
-                                    "count": "@max(body('Select_expire_seconds'))",
-                                    "unit": "Second"
-                                }
                             }
                         },
                         "Initialize_cursor": {
@@ -2421,42 +1336,6 @@
                                 ]
                             }
                         },
-                        "Set_apiResponse": {
-                            "type": "SetVariable",
-                            "inputs": {
-                                "name": "apiResponse",
-                                "value": "@body('Get_General_Host_Info')"
-                            },
-                            "runAfter": {
-                                "Get_General_Host_Info": [
-                                    "Succeeded"
-                                ]
-                            }
-                        },
-                        "Set_cursor": {
-                            "type": "SetVariable",
-                            "inputs": {
-                                "name": "cursor",
-                                "value": "@body('Parse_API_response')?['data']?['endpoints']?['pageInfo']?['endCursor']"
-                            },
-                            "runAfter": {
-                                "Exit_early_If_Tanium_Has_No_Data_for_Incident": [
-                                    "Succeeded"
-                                ]
-                            }
-                        },
-                        "Set_endpoints_list": {
-                            "type": "SetVariable",
-                            "inputs": {
-                                "name": "endpoints",
-                                "value": "@body('Parse_API_response')?['data']?['endpoints']?['edges']"
-                            },
-                            "runAfter": {
-                                "Exit_early_If_Tanium_Has_No_Data_for_Incident": [
-                                    "Succeeded"
-                                ]
-                            }
-                        },
                         "Initialize_allComputersGroupId": {
                             "type": "InitializeVariable",
                             "inputs": {
@@ -2468,7 +1347,7 @@
                                 ]
                             },
                             "runAfter": {
-                                "Add_comment_to_incident_-_hosts_that_will_be_targeted": [
+                                "Get_information_about_incident_hosts_from_Tanium": [
                                     "Succeeded"
                                 ]
                             }
@@ -2546,6 +1425,1144 @@
                             "runAfter": {
                                 "Exit_early_if_no_unquarantine_actions_were_successfully_issued": [
                                     "Succeeded"
+                                ]
+                            }
+                        },
+                        "Get_information_about_incident_hosts_from_Tanium": {
+                            "type": "Scope",
+                            "description": "Gets the information about the incident hosts from Tanium and adds a comment to sentinel listing the host to be targeted",
+                            "actions": {
+                                "Get_General_Host_Info": {
+                                    "type": "Http",
+                                    "description": "Get information about the incident hosts from Tanium.",
+                                    "inputs": {
+                                        "uri": "@parameters('TaniumApiGatewayApi')",
+                                        "method": "POST",
+                                        "headers": {
+                                            "Content-Type": "application/json",
+                                            "session": "@parameters('TaniumApiToken')"
+                                        },
+                                        "body": {
+                                            "query": "@variables('apiQuery')",
+                                            "variables": "@json(variables('apiVariables'))"
+                                        }
+                                    },
+                                    "runtimeConfiguration": {
+                                        "secureData": {
+                                            "properties": [
+                                                "inputs"
+                                            ]
+                                        }
+                                    }
+                                },
+                                "Set_apiResponse": {
+                                    "type": "SetVariable",
+                                    "inputs": {
+                                        "name": "apiResponse",
+                                        "value": "@body('Get_General_Host_Info')"
+                                    },
+                                    "runAfter": {
+                                        "Get_General_Host_Info": [
+                                            "SUCCEEDED"
+                                        ]
+                                    }
+                                },
+                                "Switch_to_TS_from_TDS_if_needed": {
+                                    "type": "If",
+                                    "description": "Switch from asking the Tanium Server for information to using the Tanium Data Service.",
+                                    "expression": {
+                                        "and": [
+                                            {
+                                                "contains": [
+                                                    "@string(body('Get_General_Host_Info'))",
+                                                    "must refer to an existing sensor"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "actions": {
+                                        "Requery_the_API_Gateway": {
+                                            "type": "Http",
+                                            "inputs": {
+                                                "uri": "@parameters('TaniumApiGatewayApi')",
+                                                "method": "POST",
+                                                "headers": {
+                                                    "Content-Type": "application/json",
+                                                    "session": "@parameters('TaniumApiToken')"
+                                                },
+                                                "body": {
+                                                    "query": "@variables('apiQuery')",
+                                                    "variables": "@json(variables('apiVariables'))"
+                                                }
+                                            },
+                                            "runAfter": {
+                                                "Update_API_Query_variables_to_get_new_source": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "runtimeConfiguration": {
+                                                "secureData": {
+                                                    "properties": [
+                                                        "inputs"
+                                                    ]
+                                                }
+                                            }
+                                        },
+                                        "Change_Endpoint_Source_to_TS": {
+                                            "type": "SetVariable",
+                                            "inputs": {
+                                                "name": "endpointSource",
+                                                "value": {
+                                                    "ts": {
+                                                        "stableWaitTime": 30
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "Update_API_Gateway_Response": {
+                                            "type": "SetVariable",
+                                            "inputs": {
+                                                "name": "apiResponse",
+                                                "value": "@body('Requery_the_API_Gateway')"
+                                            },
+                                            "runAfter": {
+                                                "Requery_the_API_Gateway": [
+                                                    "Succeeded"
+                                                ]
+                                            }
+                                        },
+                                        "Update_API_Query_variables_to_get_new_source": {
+                                            "type": "SetVariable",
+                                            "inputs": {
+                                                "name": "apiVariables",
+                                                "value": "{\n  \"source\": @{variables('endpointSource')},\n  \"incidentHosts\": {\n    \"any\": true,\n    \"filters\": @{variables('endpointFilters')}\n  }\n}"
+                                            },
+                                            "runAfter": {
+                                                "Change_Endpoint_Source_to_TS": [
+                                                    "Succeeded"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "else": {
+                                        "actions": {}
+                                    },
+                                    "runAfter": {
+                                        "Set_apiResponse": [
+                                            "SUCCEEDED"
+                                        ]
+                                    }
+                                },
+                                "Parse_API_response": {
+                                    "type": "ParseJson",
+                                    "inputs": {
+                                        "content": "@variables('apiResponse')",
+                                        "schema": {
+                                            "properties": {
+                                                "data": {
+                                                    "properties": {
+                                                        "endpoints": {
+                                                            "properties": {
+                                                                "edges": {
+                                                                    "items": {
+                                                                        "properties": {
+                                                                            "node": {
+                                                                                "properties": {},
+                                                                                "type": "object"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "node"
+                                                                        ],
+                                                                        "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                },
+                                                                "pageInfo": {
+                                                                    "properties": {
+                                                                        "endCursor": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "hasNextPage": {
+                                                                            "type": "boolean"
+                                                                        }
+                                                                    },
+                                                                    "type": "object"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                },
+                                                "errors": {
+                                                    "items": {
+                                                        "properties": {
+                                                            "message": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "message"
+                                                        ],
+                                                        "type": "object"
+                                                    },
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "runAfter": {
+                                        "Switch_to_TS_from_TDS_if_needed": [
+                                            "SUCCEEDED"
+                                        ]
+                                    }
+                                },
+                                "Exit_early_If_Tanium_Has_No_Data_for_Incident": {
+                                    "type": "If",
+                                    "expression": {
+                                        "and": [
+                                            {
+                                                "equals": [
+                                                    "@body('Parse_API_response')?['data']?['endpoints']?['pageInfo']?['endCursor']",
+                                                    "@null"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "actions": {
+                                        "Add_comment__-_no_data_in_Tanium": {
+                                            "type": "ApiConnection",
+                                            "inputs": {
+                                                "host": {
+                                                    "connection": {
+                                                        "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                                    }
+                                                },
+                                                "method": "post",
+                                                "body": {
+                                                    "incidentArmId": "@triggerBody()?['object']?['id']",
+                                                    "message": "<p>No data found in Tanium for hosts.</p>"
+                                                },
+                                                "path": "/Incidents/Comment"
+                                            }
+                                        },
+                                        "Exit_early__-_no_data_in_Tanium": {
+                                            "type": "Terminate",
+                                            "inputs": {
+                                                "runStatus": "Succeeded"
+                                            },
+                                            "runAfter": {
+                                                "Add_comment__-_no_data_in_Tanium": [
+                                                    "Succeeded"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "else": {
+                                        "actions": {}
+                                    },
+                                    "runAfter": {
+                                        "Parse_API_response": [
+                                            "SUCCEEDED"
+                                        ]
+                                    }
+                                },
+                                "Set_cursor": {
+                                    "type": "SetVariable",
+                                    "inputs": {
+                                        "name": "cursor",
+                                        "value": "@body('Parse_API_response')?['data']?['endpoints']?['pageInfo']?['endCursor']"
+                                    },
+                                    "runAfter": {
+                                        "Exit_early_If_Tanium_Has_No_Data_for_Incident": [
+                                            "SUCCEEDED"
+                                        ]
+                                    }
+                                },
+                                "Set_endpoints_list": {
+                                    "type": "SetVariable",
+                                    "inputs": {
+                                        "name": "endpoints",
+                                        "value": "@body('Parse_API_response')?['data']?['endpoints']?['edges']"
+                                    },
+                                    "runAfter": {
+                                        "Exit_early_If_Tanium_Has_No_Data_for_Incident": [
+                                            "SUCCEEDED"
+                                        ]
+                                    }
+                                },
+                                "Loop_Paginated_Response_if_has_multiple_pages": {
+                                    "type": "If",
+                                    "expression": {
+                                        "and": [
+                                            {
+                                                "equals": [
+                                                    "@body('Parse_API_response')?['data']?['endpoints']?['pageInfo']?['hasNextPage']",
+                                                    "@true"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "actions": {
+                                        "Until_no_more_pages": {
+                                            "type": "Until",
+                                            "expression": "@equals(body('Parse_page')?['data']?['endpoints']?['pageInfo']?['hasNextPage'],false)",
+                                            "limit": {
+                                                "count": 60,
+                                                "timeout": "PT1H"
+                                            },
+                                            "actions": {
+                                                "For_each_endpoint_in_paginated_API_Gateway_response": {
+                                                    "type": "Foreach",
+                                                    "foreach": "@body('Parse_page')?['data']?['endpoints']?['edges']",
+                                                    "actions": {
+                                                        "Append_endpoint_to_endpoints": {
+                                                            "type": "AppendToArrayVariable",
+                                                            "inputs": {
+                                                                "name": "endpoints",
+                                                                "value": "@items('For_each_endpoint_in_paginated_API_Gateway_response')"
+                                                            }
+                                                        }
+                                                    },
+                                                    "runAfter": {
+                                                        "Update_cursor_to_next_page": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
+                                                    "runtimeConfiguration": {
+                                                        "concurrency": {
+                                                            "repetitions": 1
+                                                        }
+                                                    }
+                                                },
+                                                "Get_next_page": {
+                                                    "type": "Http",
+                                                    "inputs": {
+                                                        "uri": "@parameters('TaniumApiGatewayApi')",
+                                                        "method": "POST",
+                                                        "headers": {
+                                                            "Content-Type": "application/json",
+                                                            "session": "@parameters('TaniumApiToken')"
+                                                        },
+                                                        "body": {
+                                                            "query": "@variables('apiQuery')",
+                                                            "variables": "@json(variables('apiVariables'))"
+                                                        }
+                                                    },
+                                                    "runAfter": {
+                                                        "Update_cursor_for_next_page": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
+                                                    "runtimeConfiguration": {
+                                                        "secureData": {
+                                                            "properties": [
+                                                                "inputs"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "Parse_page": {
+                                                    "type": "ParseJson",
+                                                    "inputs": {
+                                                        "content": "@body('Get_next_page')",
+                                                        "schema": {
+                                                            "properties": {
+                                                                "data": {
+                                                                    "properties": {
+                                                                        "endpoints": {
+                                                                            "properties": {
+                                                                                "edges": {
+                                                                                    "items": {
+                                                                                        "properties": {
+                                                                                            "node": {
+                                                                                                "type": "object"
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "node"
+                                                                                        ],
+                                                                                        "type": "object"
+                                                                                    },
+                                                                                    "type": "array"
+                                                                                },
+                                                                                "pageInfo": {
+                                                                                    "properties": {
+                                                                                        "endCursor": {
+                                                                                            "type": [
+                                                                                                "string",
+                                                                                                "null"
+                                                                                            ]
+                                                                                        },
+                                                                                        "hasNextPage": {
+                                                                                            "type": "boolean"
+                                                                                        }
+                                                                                    },
+                                                                                    "type": "object"
+                                                                                }
+                                                                            },
+                                                                            "type": "object"
+                                                                        }
+                                                                    },
+                                                                    "type": "object"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        }
+                                                    },
+                                                    "runAfter": {
+                                                        "Get_next_page": [
+                                                            "Succeeded"
+                                                        ]
+                                                    }
+                                                },
+                                                "Update_cursor_to_next_page": {
+                                                    "type": "SetVariable",
+                                                    "inputs": {
+                                                        "name": "cursor",
+                                                        "value": "@body('Parse_page')?['data']?['endpoints']?['pageInfo']?['endCursor']"
+                                                    },
+                                                    "runAfter": {
+                                                        "Parse_page": [
+                                                            "Succeeded"
+                                                        ]
+                                                    }
+                                                },
+                                                "Update_cursor_for_next_page": {
+                                                    "type": "SetVariable",
+                                                    "inputs": {
+                                                        "name": "apiQuery",
+                                                        "value": "{\n  \"source\": @{variables('endpointSource')},\n  \"endCursor\": \"@{variables('cursor')}\"\n}"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "else": {
+                                        "actions": {}
+                                    },
+                                    "runAfter": {
+                                        "Set_cursor": [
+                                            "SUCCEEDED"
+                                        ],
+                                        "Set_endpoints_list": [
+                                            "SUCCEEDED"
+                                        ]
+                                    }
+                                },
+                                "Parse_endpoints_array": {
+                                    "type": "ParseJson",
+                                    "description": "We need an action's output to use in the JavaScript code since it can't read from a variable",
+                                    "inputs": {
+                                        "content": "@variables('endpoints')",
+                                        "schema": {
+                                            "type": "array"
+                                        }
+                                    },
+                                    "runAfter": {
+                                        "Loop_Paginated_Response_if_has_multiple_pages": [
+                                            "SUCCEEDED"
+                                        ]
+                                    }
+                                },
+                                "Flatten_API_Gateway_endpoints": {
+                                    "type": "JavaScriptCode",
+                                    "inputs": {
+                                        "code": "var e = workflowContext.actions.Parse_endpoints_array.outputs.body;\r\n\r\nfunction sensorReadings(r) {\r\n\treturn r.columns.map(c => {\r\n\t\tif (c.sensor && c.sensor.name) {\r\n\t\t\treturn { name: [c.sensor.name, c.name].join(' - '), value: c.values.join(' ') };\r\n\t\t} else {\r\n\t\t\treturn { name: c.name, value: c.values.join(' ') };\r\n\t\t}\r\n\t});\r\n}\r\n\r\nfunction flatten(obj, pk = '') {\r\n\tif (pk !== '') pk += ' ';\r\n\tlet flat = {};\r\n\tObject.keys(obj).forEach((key) => {\r\n\t\tif (key === 'sensorReadings') {\r\n\t\t\tsensorReadings(obj[key]).forEach((r) => {\r\n\t\t\t\tflat[r.name] = r.value;\r\n\t\t\t});\r\n\t\t} else {\r\n\t\t\tif (typeof obj[key] === 'object' && obj[key] !== null) {\r\n\t\t\t\tObject.assign(flat, flatten(obj[key], pk + key));\r\n\t\t\t} else {\r\n\t\t\t\tflat[pk + key] = obj[key];\r\n\t\t\t}\r\n\t\t}\r\n\t});\r\n\treturn flat;\r\n}\r\n\r\nreturn e.map(function(e) { return flatten(e.node); });"
+                                    },
+                                    "runAfter": {
+                                        "Parse_endpoints_array": [
+                                            "SUCCEEDED"
+                                        ]
+                                    }
+                                },
+                                "Create_HTML_table_of_matched_endpoints": {
+                                    "type": "Table",
+                                    "inputs": {
+                                        "from": "@body('Flatten_API_Gateway_endpoints')",
+                                        "format": "HTML"
+                                    },
+                                    "runAfter": {
+                                        "Flatten_API_Gateway_endpoints": [
+                                            "SUCCEEDED"
+                                        ]
+                                    }
+                                },
+                                "Add_comment_to_incident_-_hosts_that_will_be_targeted": {
+                                    "type": "ApiConnection",
+                                    "inputs": {
+                                        "host": {
+                                            "connection": {
+                                                "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                            }
+                                        },
+                                        "method": "post",
+                                        "body": {
+                                            "incidentArmId": "@triggerBody()?['object']?['id']",
+                                            "message": "<p>Preparing to issue quarantine actions targeting these endpoints associated with this incident<br>\n@{body('Create_HTML_table_of_matched_endpoints')}</p>"
+                                        },
+                                        "path": "/Incidents/Comment"
+                                    },
+                                    "runAfter": {
+                                        "Create_HTML_table_of_matched_endpoints": [
+                                            "SUCCEEDED"
+                                        ]
+                                    }
+                                }
+                            },
+                            "runAfter": {
+                                "Initialize_API_Variables": [
+                                    "Succeeded"
+                                ],
+                                "Initialize_API_Query": [
+                                    "Succeeded"
+                                ],
+                                "Initialize_cursor": [
+                                    "Succeeded"
+                                ],
+                                "Initialize_endpoints_array": [
+                                    "Succeeded"
+                                ]
+                            }
+                        },
+                        "Generate_the_endpoints_filters_for_each_OS_package": {
+                            "type": "Scope",
+                            "description": "Generates a filter each for Windows, Mac & Linux to be used by our requests to apply the unquarantine package to the endpoints",
+                            "actions": {
+                                "For_each_host_on_the_incident": {
+                                    "type": "Foreach",
+                                    "description": "Loop through each host that was on the incident and where Tanium had data about the host",
+                                    "foreach": "@variables('endpoints')",
+                                    "actions": {
+                                        "Compose_endpoint_filter_for_packages": {
+                                            "type": "Compose",
+                                            "description": "Compose the filter for the current incident host to be used to get the unquarantine package",
+                                            "inputs": {
+                                                "and_flag": true,
+                                                "filters": [
+                                                    {
+                                                        "operator": "Equal",
+                                                        "sensor": {
+                                                            "name": "Computer Name"
+                                                        },
+                                                        "value": "@body('Parse_endpoint_JSON_data')?['node']?['name']"
+                                                    },
+                                                    {
+                                                        "operator": "RegexMatch",
+                                                        "sensor": {
+                                                            "name": "IP Address"
+                                                        },
+                                                        "value": "@body('Parse_endpoint_JSON_data')?['node']?['ipAddress']"
+                                                    }
+                                                ]
+                                            },
+                                            "runAfter": {
+                                                "Parse_endpoint_JSON_data": [
+                                                    "Succeeded"
+                                                ]
+                                            }
+                                        },
+                                        "Parse_endpoint_JSON_data": {
+                                            "type": "ParseJson",
+                                            "inputs": {
+                                                "content": "@items('For_each_host_on_the_incident')",
+                                                "schema": {
+                                                    "properties": {
+                                                        "node": {
+                                                            "properties": {
+                                                                "ipAddress": {
+                                                                    "type": "string"
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                },
+                                                                "os": {
+                                                                    "properties": {
+                                                                        "platform": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "type": "object"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                }
+                                            }
+                                        },
+                                        "Switch": {
+                                            "type": "Switch",
+                                            "expression": "@body('Parse_endpoint_JSON_data')?['node']?['os']?['platform']",
+                                            "default": {
+                                                "actions": {}
+                                            },
+                                            "cases": {
+                                                "Linux": {
+                                                    "actions": {
+                                                        "Append_to_Linux_endpoint_filters": {
+                                                            "type": "AppendToArrayVariable",
+                                                            "inputs": {
+                                                                "name": "linuxEndpointFilters",
+                                                                "value": "@outputs('Compose_endpoint_filter_for_packages')"
+                                                            }
+                                                        }
+                                                    },
+                                                    "case": "Linux"
+                                                },
+                                                "Mac": {
+                                                    "actions": {
+                                                        "Append_to_macOS_endpoint_filters": {
+                                                            "type": "AppendToArrayVariable",
+                                                            "inputs": {
+                                                                "name": "macOsEndpointFilters",
+                                                                "value": "@outputs('Compose_endpoint_filter_for_packages')"
+                                                            }
+                                                        }
+                                                    },
+                                                    "case": "Mac"
+                                                },
+                                                "Windows": {
+                                                    "actions": {
+                                                        "Append_to_Windows_endpoint_filters": {
+                                                            "type": "AppendToArrayVariable",
+                                                            "inputs": {
+                                                                "name": "windowsEndpointFilters",
+                                                                "value": "@outputs('Compose_endpoint_filter_for_packages')"
+                                                            }
+                                                        }
+                                                    },
+                                                    "case": "Windows"
+                                                }
+                                            },
+                                            "runAfter": {
+                                                "Compose_endpoint_filter_for_packages": [
+                                                    "Succeeded"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "runAfter": {
+                                "Set_allComputersGroupId": [
+                                    "Succeeded"
+                                ]
+                            }
+                        },
+                        "Check_results_of_quarantine_action": {
+                            "type": "Scope",
+                            "actions": {
+                                "Select_expire_seconds": {
+                                    "type": "Select",
+                                    "inputs": {
+                                        "from": "@variables('issuedActions')",
+                                        "select": "@int(item()?['expire_seconds'])"
+                                    }
+                                },
+                                "Wait_for_the_max_expire_seconds_from_the_issued_actions": {
+                                    "type": "Wait",
+                                    "inputs": {
+                                        "interval": {
+                                            "count": "@max(body('Select_expire_seconds'))",
+                                            "unit": "Second"
+                                        }
+                                    },
+                                    "runAfter": {
+                                        "Select_expire_seconds": [
+                                            "SUCCEEDED"
+                                        ]
+                                    }
+                                },
+                                "Collect_action_results_for_each_issued_action": {
+                                    "type": "Foreach",
+                                    "foreach": "@variables('issuedActions')",
+                                    "actions": {
+                                        "Get_action_result": {
+                                            "type": "Http",
+                                            "inputs": {
+                                                "uri": "@{concat(parameters('TaniumActionResultDataUrlFragment'), items('Collect_action_results_for_each_issued_action')?['id'])}",
+                                                "method": "GET",
+                                                "headers": {
+                                                    "Content-Type": "application/json",
+                                                    "session": "@parameters('TaniumApiToken')"
+                                                }
+                                            },
+                                            "runtimeConfiguration": {
+                                                "secureData": {
+                                                    "properties": [
+                                                        "inputs"
+                                                    ]
+                                                }
+                                            }
+                                        },
+                                        "If_action_result_could_be_determined": {
+                                            "type": "If",
+                                            "expression": {
+                                                "and": [
+                                                    {
+                                                        "greater": [
+                                                            "@length(outputs('Parse_action_result')['body'])",
+                                                            0
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "actions": {
+                                                "For_each_action_result_set": {
+                                                    "type": "Foreach",
+                                                    "foreach": "@body('Parse_action_result')",
+                                                    "actions": {
+                                                        "Append_to_action_results": {
+                                                            "type": "AppendToArrayVariable",
+                                                            "inputs": {
+                                                                "name": "knownActionResults",
+                                                                "value": "@item()"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "else": {
+                                                "actions": {
+                                                    "Append_to_unknown_action_results": {
+                                                        "type": "AppendToArrayVariable",
+                                                        "inputs": {
+                                                            "name": "unknownActionResults",
+                                                            "value": "@outputs('Compose_unknown_action_result')"
+                                                        },
+                                                        "runAfter": {
+                                                            "Compose_unknown_action_result": [
+                                                                "Succeeded"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "Compose_unknown_action_result": {
+                                                        "type": "Compose",
+                                                        "inputs": {
+                                                            "action id": "@item()?['id']",
+                                                            "status": "Completed with unknown result"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "runAfter": {
+                                                "Parse_action_result": [
+                                                    "Succeeded"
+                                                ]
+                                            }
+                                        },
+                                        "Parse_action_result": {
+                                            "type": "JavaScriptCode",
+                                            "inputs": {
+                                                "code": "var action_results = workflowContext.actions.Get_action_result.outputs.body.data;\r\nvar action_id = workflowContext.actions.Parse_current_issued_action.outputs.body.id;\r\nvar columns = action_results.result_sets[0].columns.map(c => c.name);\r\nvar robjects = [];\r\n\r\naction_results.result_sets.forEach(function(rs) {\r\n\trs.rows.forEach(function(row) {\r\n\t\tlet robject = {'action id': action_id};\r\n\t\tcolumns.forEach(function(c, i) {\r\n\t\t\trobject[c] = row.data[i][0].text;\r\n\t\t});\r\n\t\trobjects.push(robject);\r\n\t});\r\n});\r\n\r\nreturn robjects;"
+                                            },
+                                            "runAfter": {
+                                                "Parse_current_issued_action": [
+                                                    "Succeeded"
+                                                ]
+                                            }
+                                        },
+                                        "Parse_current_issued_action": {
+                                            "type": "ParseJson",
+                                            "inputs": {
+                                                "content": "@items('Collect_action_results_for_each_issued_action')",
+                                                "schema": {
+                                                    "properties": {
+                                                        "action_group": {
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "integer"
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "approver": {
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "integer"
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "comment": {
+                                                            "type": "string"
+                                                        },
+                                                        "creation_time": {
+                                                            "type": "string"
+                                                        },
+                                                        "distribute_seconds": {
+                                                            "type": "integer"
+                                                        },
+                                                        "expiration_time": {
+                                                            "type": "string"
+                                                        },
+                                                        "expire_seconds": {
+                                                            "type": "integer"
+                                                        },
+                                                        "history_saved_question": {
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "integer"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "id": {
+                                                            "type": "integer"
+                                                        },
+                                                        "name": {
+                                                            "type": "string"
+                                                        },
+                                                        "package_spec": {
+                                                            "properties": {
+                                                                "available_time": {
+                                                                    "type": "string"
+                                                                },
+                                                                "command": {
+                                                                    "type": "string"
+                                                                },
+                                                                "command_timeout": {
+                                                                    "type": "integer"
+                                                                },
+                                                                "content_set": {
+                                                                    "properties": {
+                                                                        "id": {
+                                                                            "type": "integer"
+                                                                        },
+                                                                        "name": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "type": "object"
+                                                                },
+                                                                "creation_time": {
+                                                                    "type": "string"
+                                                                },
+                                                                "deleted_flag": {
+                                                                    "type": "boolean"
+                                                                },
+                                                                "display_name": {
+                                                                    "type": "string"
+                                                                },
+                                                                "expire_seconds": {
+                                                                    "type": "integer"
+                                                                },
+                                                                "hidden_flag": {
+                                                                    "type": "boolean"
+                                                                },
+                                                                "id": {
+                                                                    "type": "integer"
+                                                                },
+                                                                "last_modified_by": {
+                                                                    "type": "string"
+                                                                },
+                                                                "last_update": {
+                                                                    "type": "string"
+                                                                },
+                                                                "mod_user": {
+                                                                    "properties": {
+                                                                        "display_name": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "domain": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "id": {
+                                                                            "type": "integer"
+                                                                        },
+                                                                        "name": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "type": "object"
+                                                                },
+                                                                "modification_time": {
+                                                                    "type": "string"
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                },
+                                                                "parameter_definition": {
+                                                                    "type": "string"
+                                                                },
+                                                                "process_group_flag": {
+                                                                    "type": "boolean"
+                                                                },
+                                                                "skip_lock_flag": {
+                                                                    "type": "boolean"
+                                                                },
+                                                                "source_hash": {
+                                                                    "type": "string"
+                                                                },
+                                                                "verify_expire_seconds": {
+                                                                    "type": "integer"
+                                                                },
+                                                                "verify_group": {
+                                                                    "properties": {
+                                                                        "id": {
+                                                                            "type": "integer"
+                                                                        }
+                                                                    },
+                                                                    "type": "object"
+                                                                },
+                                                                "verify_group_id": {
+                                                                    "type": "integer"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "saved_action": {
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "integer"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "skip_lock_flag": {
+                                                            "type": "boolean"
+                                                        },
+                                                        "start_time": {
+                                                            "type": "string"
+                                                        },
+                                                        "status": {
+                                                            "type": "string"
+                                                        },
+                                                        "stopped_flag": {
+                                                            "type": "boolean"
+                                                        },
+                                                        "target_group": {
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "integer"
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "user": {
+                                                            "properties": {
+                                                                "creation_time": {
+                                                                    "type": "string"
+                                                                },
+                                                                "deleted_flag": {
+                                                                    "type": "boolean"
+                                                                },
+                                                                "display_name": {
+                                                                    "type": "string"
+                                                                },
+                                                                "domain": {
+                                                                    "type": "string"
+                                                                },
+                                                                "effective_group_id": {
+                                                                    "type": "integer"
+                                                                },
+                                                                "external_flag": {
+                                                                    "type": "integer"
+                                                                },
+                                                                "group_id": {
+                                                                    "type": "integer"
+                                                                },
+                                                                "id": {
+                                                                    "type": "integer"
+                                                                },
+                                                                "last_login": {
+                                                                    "type": "string"
+                                                                },
+                                                                "locked_out": {
+                                                                    "type": "integer"
+                                                                },
+                                                                "mod_user": {
+                                                                    "properties": {
+                                                                        "display_name": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "domain": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "id": {
+                                                                            "type": "integer"
+                                                                        },
+                                                                        "name": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "type": "object"
+                                                                },
+                                                                "modification_time": {
+                                                                    "type": "string"
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                },
+                                                                "previous_login": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                }
+                                            },
+                                            "runAfter": {
+                                                "Get_action_result": [
+                                                    "Succeeded"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "runAfter": {
+                                        "Wait_for_the_max_expire_seconds_from_the_issued_actions": [
+                                            "SUCCEEDED"
+                                        ]
+                                    },
+                                    "runtimeConfiguration": {
+                                        "concurrency": {
+                                            "repetitions": 1
+                                        }
+                                    }
+                                },
+                                "Create_HTML_table_of_action_results": {
+                                    "type": "Table",
+                                    "inputs": {
+                                        "from": "@variables('knownActionResults')",
+                                        "format": "HTML"
+                                    },
+                                    "runAfter": {
+                                        "Collect_action_results_for_each_issued_action": [
+                                            "SUCCEEDED"
+                                        ]
+                                    }
+                                },
+                                "Create_HTML_table_of_unknown_action_results": {
+                                    "type": "Table",
+                                    "inputs": {
+                                        "from": "@variables('unknownActionResults')",
+                                        "format": "HTML"
+                                    },
+                                    "runAfter": {
+                                        "Collect_action_results_for_each_issued_action": [
+                                            "SUCCEEDED"
+                                        ]
+                                    }
+                                },
+                                "If_action_results_and_unknown_action_results": {
+                                    "type": "If",
+                                    "expression": {
+                                        "and": [
+                                            {
+                                                "greater": [
+                                                    "@length(variables('knownActionResults'))",
+                                                    0
+                                                ]
+                                            },
+                                            {
+                                                "greater": [
+                                                    "@length(variables('unknownActionResults'))",
+                                                    0
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "actions": {
+                                        "Add_comment_to_incident_-_known_and_unknown_action_results": {
+                                            "type": "ApiConnection",
+                                            "inputs": {
+                                                "host": {
+                                                    "connection": {
+                                                        "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                                    }
+                                                },
+                                                "method": "post",
+                                                "body": {
+                                                    "incidentArmId": "@triggerBody()?['object']?['id']",
+                                                    "message": "<p>QUARANTINE ACTION RESULTS<br>\n@{body('Create_HTML_table_of_action_results')}<br>\n<br>\n@{body('Create_HTML_table_of_unknown_action_results')}</p>"
+                                                },
+                                                "path": "/Incidents/Comment"
+                                            }
+                                        }
+                                    },
+                                    "else": {
+                                        "actions": {
+                                            "If_action_results": {
+                                                "type": "If",
+                                                "expression": {
+                                                    "and": [
+                                                        {
+                                                            "greater": [
+                                                                "@length(variables('knownActionResults'))",
+                                                                0
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "actions": {
+                                                    "Add_comment_to_incident_-_known_action_results": {
+                                                        "type": "ApiConnection",
+                                                        "inputs": {
+                                                            "host": {
+                                                                "connection": {
+                                                                    "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                                                }
+                                                            },
+                                                            "method": "post",
+                                                            "body": {
+                                                                "incidentArmId": "@triggerBody()?['object']?['id']",
+                                                                "message": "<p>QUARANTINE ACTION RESULTS<br>\n@{body('Create_HTML_table_of_action_results')}</p>"
+                                                            },
+                                                            "path": "/Incidents/Comment"
+                                                        }
+                                                    }
+                                                },
+                                                "else": {
+                                                    "actions": {
+                                                        "Add_comment_to_incident_-_unknown_action_results": {
+                                                            "type": "ApiConnection",
+                                                            "inputs": {
+                                                                "host": {
+                                                                    "connection": {
+                                                                        "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                                                    }
+                                                                },
+                                                                "method": "post",
+                                                                "body": {
+                                                                    "incidentArmId": "@triggerBody()?['object']?['id']",
+                                                                    "message": "<p>QUARANTINE ACTION RESULTS<br>\n@{body('Create_HTML_table_of_unknown_action_results')}</p>"
+                                                                },
+                                                                "path": "/Incidents/Comment"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "runAfter": {
+                                        "Create_HTML_table_of_action_results": [
+                                            "SUCCEEDED"
+                                        ],
+                                        "Create_HTML_table_of_unknown_action_results": [
+                                            "SUCCEEDED"
+                                        ]
+                                    }
+                                }
+                            },
+                            "runAfter": {
+                                "Initialize_action_results": [
+                                    "SUCCEEDED"
                                 ]
                             }
                         }

--- a/Solutions/Tanium/Playbooks/Tanium-UnquarantineHosts/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-UnquarantineHosts/azuredeploy.json
@@ -49,10 +49,10 @@
             }
         },
         "TaniumServerHostname": {
-            "defaultValue": "hostname",
+            "defaultValue": "<customerName>-api.cloud.tanium.com",
             "type": "String",
             "metadata": {
-                "description": "The hostname for your Tanium server e.g. tanium.example.com"
+                "description": "The hostname for your Tanium server's API. For cloud customers use <customerName>-api.cloud.tanium.com. For on-onprem use the hostname of your server."
             }
         }
     },

--- a/Solutions/Tanium/Playbooks/Tanium-UnquarantineHosts/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-UnquarantineHosts/azuredeploy.json
@@ -702,13 +702,13 @@
                         },
                         "Flatten_API_Gateway_endpoints": {
                             "runAfter": {
-                                "Parse_endpoints_array": [
+                                "Parse_the_array_endpoints": [
                                     "Succeeded"
                                 ]
                             },
                             "type": "JavaScriptCode",
                             "inputs": {
-                                "code": "var e = workflowContext.actions.Parse_endpoints_array.outputs.body;\r\n\r\nfunction sensorReadings(r) {\r\n\treturn r.columns.map(c => {\r\n\t\tif (c.sensor && c.sensor.name) {\r\n\t\t\treturn { name: [c.sensor.name, c.name].join(' - '), value: c.values.join(' ') };\r\n\t\t} else {\r\n\t\t\treturn { name: c.name, value: c.values.join(' ') };\r\n\t\t}\r\n\t});\r\n}\r\n\r\nfunction flatten(obj, pk = '') {\r\n\tif (pk !== '') pk += ' ';\r\n\tlet flat = {};\r\n\tObject.keys(obj).forEach((key) => {\r\n\t\tif (key === 'sensorReadings') {\r\n\t\t\tsensorReadings(obj[key]).forEach((r) => {\r\n\t\t\t\tflat[r.name] = r.value;\r\n\t\t\t});\r\n\t\t} else {\r\n\t\t\tif (typeof obj[key] === 'object' && obj[key] !== null) {\r\n\t\t\t\tObject.assign(flat, flatten(obj[key], pk + key));\r\n\t\t\t} else {\r\n\t\t\t\tflat[pk + key] = obj[key];\r\n\t\t\t}\r\n\t\t}\r\n\t});\r\n\treturn flat;\r\n}\r\n\r\nreturn e.map(function(e) { return flatten(e.node); });"
+                                "code": "var e = workflowContext.actions.Parse_the_array_endpoints.outputs.body;\r\n\r\nfunction sensorReadings(r) {\r\n\treturn r.columns.map(c => {\r\n\t\tif (c.sensor && c.sensor.name) {\r\n\t\t\treturn { name: [c.sensor.name, c.name].join(' - '), value: c.values.join(' ') };\r\n\t\t} else {\r\n\t\t\treturn { name: c.name, value: c.values.join(' ') };\r\n\t\t}\r\n\t});\r\n}\r\n\r\nfunction flatten(obj, pk = '') {\r\n\tif (pk !== '') pk += ' ';\r\n\tlet flat = {};\r\n\tObject.keys(obj).forEach((key) => {\r\n\t\tif (key === 'sensorReadings') {\r\n\t\t\tsensorReadings(obj[key]).forEach((r) => {\r\n\t\t\t\tflat[r.name] = r.value;\r\n\t\t\t});\r\n\t\t} else {\r\n\t\t\tif (typeof obj[key] === 'object' && obj[key] !== null) {\r\n\t\t\t\tObject.assign(flat, flatten(obj[key], pk + key));\r\n\t\t\t} else {\r\n\t\t\t\tflat[pk + key] = obj[key];\r\n\t\t\t}\r\n\t\t}\r\n\t});\r\n\treturn flat;\r\n}\r\n\r\nreturn e.map(function(e) { return flatten(e.node); });"
                             }
                         },
                         "For_each_host_on_the_incident": {
@@ -739,7 +739,8 @@
                                                 "value": "@body('Parse_endpoint_JSON_data')?['node']?['ipAddress']"
                                             }
                                         ]
-                                    }
+                                    },
+                                    "description": "Compose the filter for the current incident host to be used to get the quarantine package"
                                 },
                                 "Parse_endpoint_JSON_data": {
                                     "type": "ParseJson",
@@ -827,7 +828,8 @@
                                     "Succeeded"
                                 ]
                             },
-                            "type": "Foreach"
+                            "type": "Foreach",
+                            "description": "Loop through each host that was on the incident and where Tanium had data about the host"
                         },
                         "Build_Endpoint_Filter_from_Hosts": {
                             "inputs": {
@@ -2189,7 +2191,10 @@
                                                                         "pageInfo": {
                                                                             "properties": {
                                                                                 "endCursor": {
-                                                                                    "type": "string"
+                                                                                    "type": [
+                                                                                        "string",
+                                                                                        "null"
+                                                                                    ]
                                                                                 },
                                                                                 "hasNextPage": {
                                                                                     "type": "boolean"
@@ -2322,7 +2327,7 @@
                                 }
                             }
                         },
-                        "Parse_endpoints_array": {
+                        "Parse_the_array_endpoints": {
                             "runAfter": {
                                 "Loop_Paginated_Response_if_has_multiple_pages": [
                                     "Succeeded"
@@ -2362,7 +2367,8 @@
                                         "inputs"
                                     ]
                                 }
-                            }
+                            },
+                            "description": "Get information about the incident hosts from Tanium."
                         },
                         "Select_expire_seconds": {
                             "runAfter": {
@@ -2459,7 +2465,8 @@
                             "type": "If",
                             "else": {
                                 "actions": {}
-                            }
+                            },
+                            "description": "Switch from asking the Tanium Server for information to using the Tanium Data Service."
                         },
                         "Wait_for_the_max_expire_seconds_from_the_issued_actions": {
                             "runAfter": {

--- a/Solutions/Tanium/Playbooks/Tanium-UnquarantineHosts/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-UnquarantineHosts/azuredeploy.json
@@ -6,13 +6,13 @@
         "description": "This playbook starts with a Microsoft Sentinel incident, gets the hosts associated with that incident, then directs Tanium to un-quarantine those hosts. The status of the un-quarantine operation is commented on the Microsoft Sentinel incident.\n\nSee [Tanium Help](https://help.tanium.com/bundle/ConnectAzureSentinel/page/Integrations/MSFT/ConnectAzureSentinel/Overview.htm) for a guide to setting up the Tanium Connector for Sentinel.",
         "prerequisites": [
             "1. Microsoft Sentinel incidents with associated hosts.",
-            "2. A [Tanium API Token](https://help.tanium.com/bundle/ug_console_cloud/page/platform_user/console_api_tokens.html) granting access to your Tanium environment: the query will be made with the user priviledges of that token."            
+            "2. A [Tanium API Token](https://help.tanium.com/bundle/ug_console_cloud/page/platform_user/console_api_tokens.html) granting access to your Tanium environment: the query will be made with the user priviledges of that token."
         ],
         "postDeploymentSteps": [
             "1. Ensure the Logic App API connection to Microsoft Sentinel is authenticated."
         ],
         "entities": [ "host" ],
-        "tags": ["Remediation"],
+        "tags": [ "Remediation" ],
         "lastUpdateTime": "2023-12-08T00:00:00.000Z",
         "support": {
             "tier": "developer",
@@ -66,17 +66,17 @@
     },
     "resources": [
         {
-          "type": "Microsoft.Web/connections",
-          "apiVersion": "2018-07-01-preview",
-          "name": "[variables('AzureSentinelConnectionName')]",
-          "location": "[resourceGroup().location]",
-          "properties": {
-              "displayName": "[variables('AzureSentinelConnectionName')]",
-              "customParameterValues": {},
-              "api": {
-                  "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/azuresentinel')]"
-              }
-          }
+            "type": "Microsoft.Web/connections",
+            "apiVersion": "2018-07-01-preview",
+            "name": "[variables('AzureSentinelConnectionName')]",
+            "location": "[resourceGroup().location]",
+            "properties": {
+                "displayName": "[variables('AzureSentinelConnectionName')]",
+                "customParameterValues": {},
+                "api": {
+                    "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/azuresentinel')]"
+                }
+            }
         },
         {
             "type": "Microsoft.Logic/workflows",
@@ -88,7 +88,7 @@
                 "hidden-SentinelTemplateVersion": "2.0"
             },
             "dependsOn": [
-              "[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]"
+                "[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]"
             ],
             "properties": {
                 "state": "Enabled",


### PR DESCRIPTION
Updated the Unquarantine Hosts playbook.

# Change Summary

## Reorganized

Reorganized and updated names of actions within the playbook to make it far more readable and easier to view/understand when in the GUI editor in Azure Portal.

## Updated Sentinel Connection

The API Connection that was created to allow the playbook to connect to Azure Sentinel (and interact, like leaving comments or using incident triggers) was having to be manually authorized and therefore also impersonating the user who authorized it.

Updated the ARM template to use managed identity for the logic app itself and then use that for the connection, so that when the playbook is created it is already authorized.

## Fixed Pagination Issue
Fixed issue with misconfigured action under pagination

## Fixed Schema Issue
Fixed a schema issue when getting the general host info from Tanium