### PR TITLE
feat(playbooks: comply findings) Added use of keyvault for api token

### DIFF
--- a/Solutions/Tanium/Playbooks/Tanium-ComplyFindings/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-ComplyFindings/azuredeploy.json
@@ -31,11 +31,21 @@
                 "description": "The name to use for the playbook. (This will exist as an Azure Logic app in your subscription)"
             }
         },
+        "KeyVaultConnectionName": {
+            "defaultValue": "Tanium-GeneralHostInfo-KeyVault-WebConn",
+            "type": "string",
+            "metadata": {
+                "description": "The name to use for the Azure Key Vault Connector in the Logic App. (This will exist as an API Connection in your subscription)"
+            }
+        },
+        "KeyVaultName": {
+            "type": "String"
+        },
         "AzureSentinelConnectionName": {
             "defaultValue": "Tanium-ComplyFindings-Sentinel-WebConn",
             "type": "string",
             "metadata": {
-                "description": "The name to use for the Microsoft Sentinel Connector in the Logic App . (This will exist as an API Connection in your subscription)"
+                "description": "The name to use for the Microsoft Sentinel Connector in the Logic App. (This will exist as an API Connection in your subscription)"
             }
         },
         "IntegrationAccountName": {
@@ -49,13 +59,6 @@
             "type": "string",
             "metadata": {
                 "description": "The resource group name for the existing Azure Integration Account"
-            }
-        },
-        "TaniumApiToken": {
-            "defaultValue": "",
-            "type": "securestring",
-            "metadata": {
-                "description": "The Tanium API Token used for this logic app. The logic app will be restricted to the level of access available to the user who generated the token."
             }
         },
         "TaniumServerHostname": {
@@ -82,6 +85,24 @@
                     "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/azuresentinel')]"
                 },
                 "parameterValueType": "Alternative"
+            }
+        },
+        {
+            "type": "Microsoft.Web/connections",
+            "apiVersion": "2016-06-01",
+            "name": "[parameters('KeyVaultConnectionName')]",
+            "location": "[resourceGroup().location]",
+            "kind": "V1",
+            "properties": {
+                "displayName": "[parameters('KeyVaultConnectionName')]",
+                "customParameterValues": {},
+                "api": {
+                    "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/keyvault')]"
+                },
+                "parameterValueType": "Alternative",
+                "alternativeParameterValues": {
+                    "vaultName": "[parameters('KeyVaultName')]"
+                }
             }
         },
         {
@@ -114,12 +135,6 @@
                         },
                         "TaniumApiGatewayApi": {
                             "type": "String"
-                        },
-                        "TaniumApiToken": {
-                            "type": "SecureString",
-                            "metadata": {
-                                "description": "The Tanium API Token provides access to the Tanium Server. Access is restricted to the level of access available to the user who generated the token."
-                            }
                         }
                     },
                     "triggers": {
@@ -431,7 +446,7 @@
                                                         },
                                                         "headers": {
                                                             "Content-Type": "application/json",
-                                                            "session": "@parameters('TaniumApiToken')"
+                                                            "session": "@{body('Get_secret')?['value']}"
                                                         },
                                                         "method": "POST",
                                                         "uri": "@parameters('TaniumApiGatewayApi')"
@@ -682,10 +697,15 @@
                                         },
                                         "headers": {
                                             "Content-Type": "application/json",
-                                            "session": "@parameters('TaniumApiToken')"
+                                            "session": "@{body('Get_secret')?['value']}"
                                         },
                                         "method": "POST",
                                         "uri": "@parameters('TaniumApiGatewayApi')"
+                                    },
+                                    "runAfter": {
+                                        "Get_secret": [
+                                            "SUCCEEDED"
+                                        ]
                                     },
                                     "runtimeConfiguration": {
                                         "secureData": {
@@ -761,7 +781,7 @@
                                                 },
                                                 "headers": {
                                                     "Content-Type": "application/json",
-                                                    "session": "@parameters('TaniumApiToken')"
+                                                    "session": "@{body('Get_secret')?['value']}"
                                                 },
                                                 "method": "POST",
                                                 "uri": "@parameters('TaniumApiGatewayApi')"
@@ -866,6 +886,26 @@
                                             "SUCCEEDED"
                                         ]
                                     }
+                                },
+                                "Get_secret": {
+                                    "type": "ApiConnection",
+                                    "inputs": {
+                                        "host": {
+                                            "connection": {
+                                                "name": "@parameters('$connections')['keyvault']['connectionId']"
+                                            }
+                                        },
+                                        "method": "get",
+                                        "path": "/secrets/@{encodeURIComponent('TaniumApiToken')}/value"
+                                    },
+                                    "runtimeConfiguration": {
+                                        "secureData": {
+                                            "properties": [
+                                                "inputs",
+                                                "outputs"
+                                            ]
+                                        }
+                                    }
                                 }
                             },
                             "runAfter": {
@@ -918,6 +958,7 @@
                 },
                 "parameters": {
                     "$connections": {
+                        "type": "Object",
                         "value": {
                             "azuresentinel": {
                                 "connectionName": "[parameters('AzureSentinelConnectionName')]",
@@ -928,11 +969,18 @@
                                         "type": "ManagedServiceIdentity"
                                     }
                                 }
+                            },
+                            "keyvault": {
+                                "connectionName": "[parameters('KeyVaultConnectionName')]",
+                                "connectionId": "[resourceId('Microsoft.Web/connections', parameters('KeyVaultConnectionName'))]",
+                                "id": "[concat('/subscriptions/',subscription().subscriptionId, '/providers/Microsoft.Web/locations/',resourceGroup().location,'/managedApis/keyvault')]",
+                                "connectionProperties": {
+                                    "authentication": {
+                                        "type": "ManagedServiceIdentity"
+                                    }
+                                }
                             }
                         }
-                    },
-                    "TaniumApiToken": {
-                        "value": "[parameters('TaniumApiToken')]"
                     },
                     "TaniumApiGatewayApi": {
                         "value": "[variables('TaniumApiGatewayApi')]"


### PR DESCRIPTION
# What
We have a Sentinel Playbook that will get the list of comply findings for all endpoints listed on a Sentinel Incident and add a comment with those findings.
I updated this playbook so that instead of taking in the API token for the Tanium API as a parameter from the user, it will read it from an Azure key vault.

In this case it meant
- Removing the old securestring parameter from the playbook
- Adding an action to get the secret from the key vault
- Updating the actions that used the removed parameter to now use the result of the new key vault action
- Adding a resource to the ARM template representing the key vault
- Adding parameters allowing users to provide the key vault name and api connection name

# Why
For release 3.2 of our Sentinel Integration we're addressing some security items. In this case, we address a few things
1. Keeping the secret in the key vault allows customers to leverage RBAC as needed. For example, giving someone access to run the playbook, but not being permissed to view the secret.
2. As a cyber security company Tanium does advise and hopes our customers will cycle secrets from time to time as a preventative measure. Now instead of having to completely redeploy the playbook and losing all historical data, they can simply update the key vault.
3. It creates one less way of the api token being exposed since a user with the necessary permission could alter the parameters so that the API Token is not treated as a secure string _(using the old approach)_. Now, they could only expose this by turning off the secure inputs on the actions using the secret. And again, customers should be setting and reviewing RBAC for all playbooks _(aka Azure Logic apps)_.

# Does it work?
It should, however at this time leadership has decided that we will first make the changes for the release and then conduct testing, rather than testing each playbook as we make changes. This is due to the work needed to automate testing being done as-can-be.

However, I did confirm that deploying the playbook via the custom deployment tool in azure did not render any errors, so it does deploy as expected, but as mentioned above the playbook run itself needs to be tested.

# How can someone else confirm these changes?
See above response.