### PR TITLE
feat(playbooks: quarantine hosts) Added use of keyvault for api token

### DIFF
--- a/Solutions/Tanium/Playbooks/Tanium-QuarantineHosts/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-QuarantineHosts/azuredeploy.json
@@ -21,18 +21,28 @@
         "author": {
             "name": "Tanium"
         },
-        "parameterTemplateVersion": "3.0.0"
+        "parameterTemplateVersion": "3.2.0"
     },
     "parameters": {
         "PlaybookName": {
             "defaultValue": "Tanium-QuarantineHosts",
             "type": "string"
         },
+        "KeyVaultConnectionName": {
+            "defaultValue": "Tanium-GeneralHostInfo-KeyVault-WebConn",
+            "type": "string",
+            "metadata": {
+                "description": "The name to use for the Azure Key Vault Connector in the Logic App. (This will exist as an API Connection in your subscription)"
+            }
+        },
+        "KeyVaultName": {
+            "type": "String"
+        },
         "AzureSentinelConnectionName": {
             "defaultValue": "Tanium-QuarantineHosts-Sentinel-WebConn",
             "type": "string",
             "metadata": {
-                "description": "The name to use for the Microsoft Sentinel Connector in the Logic App . (This will exist as an API Connection in your subscription)"
+                "description": "The name to use for the Microsoft Sentinel Connector in the Logic App. (This will exist as an API Connection in your subscription)"
             }
         },
         "IntegrationAccountName": {
@@ -46,13 +56,6 @@
             "type": "string",
             "metadata": {
                 "description": "The resource group name for the existing Azure Integration Account"
-            }
-        },
-        "TaniumApiToken": {
-            "defaultValue": "",
-            "type": "securestring",
-            "metadata": {
-                "description": "The Tanium API Token used for this logic app. The logic app will be restricted to the level of access available to the user who generated the token."
             }
         },
         "TaniumServerHostname": {
@@ -86,6 +89,24 @@
             }
         },
         {
+            "type": "Microsoft.Web/connections",
+            "apiVersion": "2016-06-01",
+            "name": "[parameters('KeyVaultConnectionName')]",
+            "location": "[resourceGroup().location]",
+            "kind": "V1",
+            "properties": {
+                "displayName": "[parameters('KeyVaultConnectionName')]",
+                "customParameterValues": {},
+                "api": {
+                    "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/keyvault')]"
+                },
+                "parameterValueType": "Alternative",
+                "alternativeParameterValues": {
+                    "vaultName": "[parameters('KeyVaultName')]"
+                }
+            }
+        },
+        {
             "type": "Microsoft.Logic/workflows",
             "apiVersion": "2019-05-01",
             "name": "[parameters('PlaybookName')]",
@@ -112,12 +133,6 @@
                         "$connections": {
                             "defaultValue": {},
                             "type": "Object"
-                        },
-                        "TaniumApiToken": {
-                            "type": "securestring",
-                            "metadata": {
-                                "description": "The Tanium API Token provides access to the Tanium Server. Access is restricted to the level of access available to the user who generated the token."
-                            }
                         },
                         "TaniumActionsApi": {
                             "type": "String"
@@ -349,7 +364,7 @@
                             "inputs": {
                                 "headers": {
                                     "Content-Type": "application/json",
-                                    "session": "@parameters('TaniumApiToken')"
+                                    "session": "@{body('Get_secret')?['value']}"
                                 },
                                 "method": "GET",
                                 "uri": "@parameters('TaniumAllComputersUrl')"
@@ -442,7 +457,7 @@
                                     "inputs": {
                                         "headers": {
                                             "Content-Type": "application/json",
-                                            "session": "@parameters('TaniumApiToken')"
+                                            "session": "@{body('Get_secret')?['value']}"
                                         },
                                         "method": "GET",
                                         "uri": "@{concat(parameters('TaniumPackagesByNameUrlFragment'), join(split(variables('linuxPackageName'), ' '), '%20'))}"
@@ -466,7 +481,7 @@
                                         "body": "@outputs('Compose_Linux_action')",
                                         "headers": {
                                             "Content-Type": "application/json",
-                                            "session": "@parameters('TaniumApiToken')"
+                                            "session": "@{body('Get_secret')?['value']}"
                                         },
                                         "method": "POST",
                                         "uri": "@parameters('TaniumActionsApi')"
@@ -697,7 +712,7 @@
                                     "inputs": {
                                         "headers": {
                                             "Content-Type": "application/json",
-                                            "session": "@parameters('TaniumApiToken')"
+                                            "session": "@{body('Get_secret')?['value']}"
                                         },
                                         "method": "GET",
                                         "uri": "@{concat(parameters('TaniumPackagesByNameUrlFragment'), join(split(variables('windowsPackageName'), ' '), '%20'))}"
@@ -721,7 +736,7 @@
                                         "body": "@outputs('Compose_windows_action')",
                                         "headers": {
                                             "Content-Type": "application/json",
-                                            "session": "@parameters('TaniumApiToken')"
+                                            "session": "@{body('Get_secret')?['value']}"
                                         },
                                         "method": "POST",
                                         "uri": "@parameters('TaniumActionsApi')"
@@ -952,7 +967,7 @@
                                     "inputs": {
                                         "headers": {
                                             "Content-Type": "application/json",
-                                            "session": "@parameters('TaniumApiToken')"
+                                            "session": "@{body('Get_secret')?['value']}"
                                         },
                                         "method": "GET",
                                         "uri": "@{concat(parameters('TaniumPackagesByNameUrlFragment'), join(split(variables('macOsPackageName'), ' '), '%20'))}"
@@ -976,7 +991,7 @@
                                         "body": "@outputs('Compose_macOS_action')",
                                         "headers": {
                                             "Content-Type": "application/json",
-                                            "session": "@parameters('TaniumApiToken')"
+                                            "session": "@{body('Get_secret')?['value']}"
                                         },
                                         "method": "POST",
                                         "uri": "@parameters('TaniumActionsApi')"
@@ -1431,7 +1446,7 @@
                                         },
                                         "headers": {
                                             "Content-Type": "application/json",
-                                            "session": "@parameters('TaniumApiToken')"
+                                            "session": "@{body('Get_secret')?['value']}"
                                         },
                                         "uri": "@parameters('TaniumApiGatewayApi')",
                                         "method": "POST"
@@ -1473,7 +1488,7 @@
                                                 },
                                                 "headers": {
                                                     "Content-Type": "application/json",
-                                                    "session": "@parameters('TaniumApiToken')"
+                                                    "session": "@{body('Get_secret')?['value']}"
                                                 },
                                                 "method": "POST",
                                                 "uri": "@parameters('TaniumApiGatewayApi')"
@@ -1724,7 +1739,7 @@
                                                         "method": "POST",
                                                         "headers": {
                                                             "Content-Type": "application/json",
-                                                            "session": "@parameters('TaniumApiToken')"
+                                                            "session": "@{body('Get_secret')?['value']}"
                                                         },
                                                         "body": {
                                                             "query": "@variables('apiQuery')",
@@ -1911,17 +1926,8 @@
                                 }
                             },
                             "runAfter": {
-                                "Initialize_API_Query": [
-                                    "Succeeded"
-                                ],
-                                "Initialize_endpoints_array": [
-                                    "Succeeded"
-                                ],
-                                "Initialize_API_Variables": [
-                                    "Succeeded"
-                                ],
-                                "Initialize_cursor": [
-                                    "Succeeded"
+                                "Get_secret": [
+                                    "SUCCEEDED"
                                 ]
                             }
                         },
@@ -2147,7 +2153,7 @@
                                                 "method": "GET",
                                                 "headers": {
                                                     "Content-Type": "application/json",
-                                                    "session": "@parameters('TaniumApiToken')"
+                                                    "session": "@{body('Get_secret')?['value']}"
                                                 },
                                                 "runtimeConfiguration": {
                                                     "secureData": {
@@ -2624,12 +2630,47 @@
                                     "SUCCEEDED"
                                 ]
                             }
+                        },
+                        "Get_secret": {
+                            "type": "ApiConnection",
+                            "inputs": {
+                                "host": {
+                                    "connection": {
+                                        "name": "@parameters('$connections')['keyvault']['connectionId']"
+                                    }
+                                },
+                                "method": "get",
+                                "path": "/secrets/@{encodeURIComponent('TaniumApiToken')}/value"
+                            },
+                            "runtimeConfiguration": {
+                                "secureData": {
+                                    "properties": [
+                                        "inputs",
+                                        "outputs"
+                                    ]
+                                }
+                            },
+                            "runAfter": {
+                                "Initialize_API_Query": [
+                                    "Succeeded"
+                                ],
+                                "Initialize_endpoints_array": [
+                                    "Succeeded"
+                                ],
+                                "Initialize_API_Variables": [
+                                    "Succeeded"
+                                ],
+                                "Initialize_cursor": [
+                                    "Succeeded"
+                                ]
+                            }
                         }
                     },
                     "outputs": {}
                 },
                 "parameters": {
                     "$connections": {
+                        "type": "Object",
                         "value": {
                             "azuresentinel": {
                                 "connectionName": "[parameters('AzureSentinelConnectionName')]",
@@ -2640,11 +2681,18 @@
                                         "type": "ManagedServiceIdentity"
                                     }
                                 }
+                            },
+                            "keyvault": {
+                                "connectionName": "[parameters('KeyVaultConnectionName')]",
+                                "connectionId": "[resourceId('Microsoft.Web/connections', parameters('KeyVaultConnectionName'))]",
+                                "id": "[concat('/subscriptions/',subscription().subscriptionId, '/providers/Microsoft.Web/locations/',resourceGroup().location,'/managedApis/keyvault')]",
+                                "connectionProperties": {
+                                    "authentication": {
+                                        "type": "ManagedServiceIdentity"
+                                    }
+                                }
                             }
                         }
-                    },
-                    "TaniumApiToken": {
-                        "value": "[parameters('TaniumApiToken')]"
                     },
                     "TaniumActionsApi": {
                         "value": "[variables('TaniumActionsApi')]"


### PR DESCRIPTION
# What
We have a Sentinel Playbook that will get the list of endpoints listed on a Sentinel Incident and attempt to quarantine them.
I updated this playbook so that instead of taking in the API token for the Tanium API as a parameter from the user, it will read it from an Azure key vault.

In this case it meant
- Removing the old securestring parameter from the playbook
- Adding an action to get the secret from the key vault
- Updating the actions that used the removed parameter to now use the result of the new key vault action
- Adding a resource to the ARM template representing the key vault
- Adding parameters allowing users to provide the key vault name and api connection name

# Why
For release 3.2 of our Sentinel Integration we're addressing some security items. In this case, we address a few things
1. Keeping the secret in the key vault allows customers to leverage RBAC as needed. For example, giving someone access to run the playbook, but not being permissed to view the secret.
2. As a cyber security company Tanium does advise and hopes our customers will cycle secrets from time to time as a preventative measure. Now instead of having to completely redeploy the playbook and losing all historical data, they can simply update the key vault.
3. It creates one less way of the api token being exposed since a user with the necessary permission could alter the parameters so that the API Token is not treated as a secure string _(using the old approach)_. Now, they could only expose this by turning off the secure inputs on the actions using the secret. And again, customers should be setting and reviewing RBAC for all playbooks _(aka Azure Logic apps)_.

# Does it work?
It should, however at this time leadership has decided that we will first make the changes for the release and then conduct testing, rather than testing each playbook as we make changes. This is due to the work needed to automate testing being done as-can-be.

However, I did confirm that deploying the playbook via the custom deployment tool in azure did not render any errors, so it does deploy as expected, but as mentioned above the playbook run itself needs to be tested.

# How can someone else confirm these changes?
See above response.