### PR TITLE
feat(playbooks: GeneralHostInfo) Added use of keyvault for api token

### DIFF
--- a/Solutions/Tanium/Playbooks/Tanium-GeneralHostInfo/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-GeneralHostInfo/azuredeploy.json
@@ -20,7 +20,7 @@
         "author": {
             "name": "Tanium"
         },
-        "parameterTemplateVersion": "3.0.0"
+        "parameterTemplateVersion": "3.2.0"
     },
     "parameters": {
         "PlaybookName": {
@@ -37,6 +37,16 @@
                 "description": "The name to use for the Microsoft Sentinel Connector in the Logic App. (This will exist as an API Connection in your subscription)"
             }
         },
+        "KeyVaultConnectionName": {
+            "defaultValue": "Tanium-GeneralHostInfo-KeyVault-WebConn",
+            "type": "string",
+            "metadata": {
+                "description": "The name to use for the Azure Key Vault Connector in the Logic App . (This will exist as an API Connection in your subscription)"
+            }
+        },
+        "KeyVaultName": {
+            "type": "String"
+        },
         "IntegrationAccountName": {
             "defaultValue": "",
             "type": "string",
@@ -49,14 +59,7 @@
             "metadata": {
                 "description": "The resource group name for the existing Azure Integration Account"
             }
-        },
-        "TaniumApiToken": {
-            "defaultValue": "",
-            "type": "securestring",
-            "metadata": {
-                "description": "The Tanium API Token used for this logic app. The logic app will be restricted to the level of access available to the user who generated the token."
-            }
-        },
+        },       
         "TaniumServerHostname": {
             "defaultValue": "<customerName>-api.cloud.tanium.com",
             "type": "String",
@@ -82,6 +85,24 @@
                     "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/azuresentinel')]"
                 },
                 "parameterValueType": "Alternative"
+            }
+        },
+        {
+            "type": "Microsoft.Web/connections",
+            "apiVersion": "2016-06-01",
+            "name": "[parameters('KeyVaultConnectionName')]",
+            "location": "[resourceGroup().location]",
+            "kind": "V1",
+            "properties": {
+                "displayName": "[parameters('KeyVaultConnectionName')]",                
+                "customParameterValues": {},
+                "api": {                    
+                    "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/keyvault')]"
+                },
+                "parameterValueType": "Alternative",
+                "alternativeParameterValues": {  
+                    "vaultName": "[parameters('KeyVaultName')]"  
+                }
             }
         },
         {
@@ -111,12 +132,6 @@
                         "$connections": {
                             "defaultValue": {},
                             "type": "Object"
-                        },
-                        "TaniumApiToken": {
-                            "type": "securestring",
-                            "metadata": {
-                                "description": "The Tanium API Token provides access to the Tanium Server. Access is restricted to the level of access available to the user who generated the token."
-                            }
                         },
                         "TaniumApiGatewayApi": {
                             "type": "String"
@@ -273,7 +288,7 @@
                         "Initialize_API_Query": {
                             "runAfter": {
                                 "Exit_early_if_incident_has_no_hosts": [
-                                    "SUCCEEDED"
+                                    "Succeeded"
                                 ]
                             },
                             "type": "InitializeVariable",
@@ -311,7 +326,7 @@
                         "Initialize_API_Response": {
                             "runAfter": {
                                 "Exit_early_if_incident_has_no_hosts": [
-                                    "SUCCEEDED"
+                                    "Succeeded"
                                 ]
                             },
                             "type": "InitializeVariable",
@@ -327,7 +342,7 @@
                         "Initialize_response_cursor": {
                             "runAfter": {
                                 "Initialize_API_Response": [
-                                    "SUCCEEDED"
+                                    "Succeeded"
                                 ]
                             },
                             "type": "InitializeVariable",
@@ -343,7 +358,7 @@
                         "Initialize_Endpoint_Filter": {
                             "runAfter": {
                                 "Exit_early_if_incident_has_no_hosts": [
-                                    "SUCCEEDED"
+                                    "Succeeded"
                                 ]
                             },
                             "type": "InitializeVariable",
@@ -359,7 +374,7 @@
                         "Initialize_Endpoint_Source_to_TDS": {
                             "runAfter": {
                                 "Exit_early_if_incident_has_no_hosts": [
-                                    "SUCCEEDED"
+                                    "Succeeded"
                                 ]
                             },
                             "type": "InitializeVariable",
@@ -380,7 +395,7 @@
                         "Initialize_list_of_endpoints": {
                             "runAfter": {
                                 "Exit_early_if_incident_has_no_hosts": [
-                                    "SUCCEEDED"
+                                    "Succeeded"
                                 ]
                             },
                             "type": "InitializeVariable",
@@ -428,7 +443,7 @@
                                     },
                                     "runAfter": {
                                         "Parse_API_response": [
-                                            "SUCCEEDED"
+                                            "Succeeded"
                                         ]
                                     },
                                     "expression": {
@@ -487,7 +502,7 @@
                                                         },
                                                         "headers": {
                                                             "Content-Type": "application/json",
-                                                            "session": "@parameters('TaniumApiToken')"
+                                                            "session": "@{body('Get_secret')?['value']}"
                                                         },
                                                         "method": "POST",
                                                         "uri": "@parameters('TaniumApiGatewayApi')"
@@ -593,10 +608,10 @@
                                     },
                                     "runAfter": {
                                         "Set_cursor": [
-                                            "SUCCEEDED"
+                                            "Succeeded"
                                         ],
                                         "Set_endpoints": [
-                                            "SUCCEEDED"
+                                            "Succeeded"
                                         ]
                                     },
                                     "expression": {
@@ -617,7 +632,7 @@
                                 "Parse_API_response": {
                                     "runAfter": {
                                         "Switch_to_TS_from_TDS_if_needed": [
-                                            "SUCCEEDED"
+                                            "Succeeded"
                                         ]
                                     },
                                     "type": "ParseJson",
@@ -701,10 +716,15 @@
                                         },
                                         "headers": {
                                             "Content-Type": "application/json",
-                                            "session": "@parameters('TaniumApiToken')"
+                                            "session": "@{body('Get_secret')?['value']}"
                                         },
                                         "method": "POST",
                                         "uri": "@parameters('TaniumApiGatewayApi')"
+                                    },
+                                    "runAfter": {
+                                        "Get_secret": [
+                                            "SUCCEEDED"
+                                        ]
                                     },
                                     "runtimeConfiguration": {
                                         "secureData": {
@@ -730,7 +750,7 @@
                                                 },
                                                 "headers": {
                                                     "Content-Type": "application/json",
-                                                    "session": "@parameters('TaniumApiToken')"
+                                                    "session": "@{body('Get_secret')?['value']}"
                                                 },
                                                 "method": "POST",
                                                 "uri": "@parameters('TaniumApiGatewayApi')"
@@ -781,7 +801,7 @@
                                     },
                                     "runAfter": {
                                         "Set_apiResponse": [
-                                            "SUCCEEDED"
+                                            "Succeeded"
                                         ]
                                     },
                                     "description": "Switch from asking the Tanium Server for information to using the Tanium Data Service.",
@@ -808,7 +828,7 @@
                                     },
                                     "runAfter": {
                                         "Get_General_Host_Info": [
-                                            "SUCCEEDED"
+                                            "Succeeded"
                                         ]
                                     }
                                 },
@@ -820,7 +840,7 @@
                                     },
                                     "runAfter": {
                                         "Exit_early_If_Tanium_Has_No_Data_for_Incident": [
-                                            "SUCCEEDED"
+                                            "Succeeded"
                                         ]
                                     }
                                 },
@@ -832,8 +852,28 @@
                                     },
                                     "runAfter": {
                                         "Exit_early_If_Tanium_Has_No_Data_for_Incident": [
-                                            "SUCCEEDED"
+                                            "Succeeded"
                                         ]
+                                    }
+                                },
+                                "Get_secret": {
+                                    "type": "ApiConnection",
+                                    "inputs": {
+                                        "host": {
+                                            "connection": {
+                                                "name": "@parameters('$connections')['keyvault']['connectionId']"
+                                            }
+                                        },
+                                        "method": "get",
+                                        "path": "/secrets/@{encodeURIComponent('TaniumApiToken')}/value"
+                                    },
+                                    "runtimeConfiguration": {
+                                        "secureData": {
+                                            "properties": [
+                                                "inputs",
+                                                "outputs"
+                                            ]
+                                        }
                                     }
                                 }
                             },
@@ -842,13 +882,13 @@
                                     "Succeeded"
                                 ],
                                 "Initialize_API_Query": [
-                                    "SUCCEEDED"
+                                    "Succeeded"
                                 ],
                                 "Initialize_list_of_endpoints": [
-                                    "SUCCEEDED"
+                                    "Succeeded"
                                 ],
                                 "Initialize_response_cursor": [
-                                    "SUCCEEDED"
+                                    "Succeeded"
                                 ]
                             }
                         },
@@ -872,6 +912,7 @@
                 },
                 "parameters": {
                     "$connections": {
+                        "type": "Object",
                         "value": {
                             "azuresentinel": {
                                 "connectionName": "[parameters('AzureSentinelConnectionName')]",
@@ -882,11 +923,18 @@
                                         "type": "ManagedServiceIdentity"
                                     }
                                 }
+                            },
+                            "keyvault": {
+                                "connectionName": "[parameters('KeyVaultConnectionName')]",
+                                "connectionId": "[resourceId('Microsoft.Web/connections', parameters('KeyVaultConnectionName'))]",
+                                "id": "[concat('/subscriptions/',subscription().subscriptionId, '/providers/Microsoft.Web/locations/',resourceGroup().location,'/managedApis/keyvault')]",
+                                "connectionProperties": {
+                                    "authentication": {
+                                        "type": "ManagedServiceIdentity"
+                                    }
+                                }
                             }
                         }
-                    },
-                    "TaniumApiToken": {
-                        "value": "[parameters('TaniumApiToken')]"
                     },
                     "TaniumApiGatewayApi": {
                         "value": "[variables('TaniumApiGatewayApi')]"


### PR DESCRIPTION
# What
We have a Sentinel Playbook that will get the general info for all endpoints listed on a Sentinel Incident and add a comment with that information.
I updated this playbook so that instead of taking in the API token for the Tanium API as a parameter from the user, it will read it from an Azure key vault.

In this case it meant
- Removing the old securestring parameter from the playbook
- Adding an action to get the secret from the key vault
- Updating the actions that used the removed parameter to now use the result of the new key vault action
- Adding a resource to the ARM template representing the key vault
- Adding parameters allowing users to provide the key vault name and api connection name

# Why
For release 3.2 of our Sentinel Integration we're addressing some security items. In this case, we address a few things
1. Keeping the secret in the key vault allows customers to leverage RBAC as needed. For example, giving someone access to run the playbook, but not being permissed to view the secret.
2. As a cyber security company Tanium does advise and hopes our customers will cycle secrets from time to time as a preventative measure. Now instead of having to completely redeploy the playbook and losing all historical data, they can simply update the key vault.
3. It creates one less way of the api token being exposed since a user with the necessary permission could alter the parameters so that the API Token is not treated as a secure string _(using the old approach)_. Now, they could only expose this by turning off the secure inputs on the actions using the secret. And again, customers should be setting and reviewing RBAC for all playbooks _(aka Azure Logic apps)_.

# Does it work?
It should, however at this time leadership has decided that we will first make the changes for the release and then conduct testing, rather than testing each playbook as we make changes. This is due to the work needed to automate testing being done as-can-be.

However, I did confirm that deploying the playbook via the custom deployment tool in azure did not render any errors, so it does deploy as expected, but as mentioned above the playbook run itself needs to be tested.

# How can someone else confirm these changes?
See above response.