### PR TITLE
feat(playbooks: all) Updated all playbooks to use key vault to get Tanium server url

### DIFF
--- a/Solutions/Tanium/Playbooks/Tanium-ComplyFindings/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-ComplyFindings/azuredeploy.json
@@ -60,17 +60,10 @@
             "metadata": {
                 "description": "The resource group name for the existing Azure Integration Account"
             }
-        },
-        "TaniumServerHostname": {
-            "defaultValue": "<customerName>-api.cloud.tanium.com",
-            "type": "string",
-            "metadata": {
-                "description": "The hostname for your Tanium server's API. For cloud customers use <customerName>-api.cloud.tanium.com. For on-prem use the hostname of your server."
-            }
         }
     },
     "variables": {
-        "TaniumApiGatewayApi": "[uri(concat('https://',parameters('TaniumServerHostname')),'/plugin/products/gateway/graphql')]"
+        "TaniumApiGatewayPath": "/plugin/products/gateway/graphql"
     },
     "resources": [
         {
@@ -133,7 +126,7 @@
                             "defaultValue": {},
                             "type": "Object"
                         },
-                        "TaniumApiGatewayApi": {
+                        "TaniumApiGatewayPath": {
                             "type": "String"
                         }
                     },
@@ -446,10 +439,10 @@
                                                         },
                                                         "headers": {
                                                             "Content-Type": "application/json",
-                                                            "session": "@{body('Get_secret')?['value']}"
+                                                            "session": "@{body('Get_API_Token')?['value']}"
                                                         },
                                                         "method": "POST",
-                                                        "uri": "@parameters('TaniumApiGatewayApi')"
+                                                        "uri": "@uri(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumApiGatewayPath')))"
                                                     },
                                                     "runtimeConfiguration": {
                                                         "secureData": {
@@ -697,13 +690,16 @@
                                         },
                                         "headers": {
                                             "Content-Type": "application/json",
-                                            "session": "@{body('Get_secret')?['value']}"
+                                            "session": "@{body('Get_API_Token')?['value']}"
                                         },
                                         "method": "POST",
-                                        "uri": "@parameters('TaniumApiGatewayApi')"
+                                        "uri": "@uri(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumApiGatewayPath')))"
                                     },
                                     "runAfter": {
-                                        "Get_secret": [
+                                        "Get_API_Token": [
+                                            "SUCCEEDED"
+                                        ],
+                                        "Get_Server_Host": [
                                             "SUCCEEDED"
                                         ]
                                     },
@@ -781,10 +777,10 @@
                                                 },
                                                 "headers": {
                                                     "Content-Type": "application/json",
-                                                    "session": "@{body('Get_secret')?['value']}"
+                                                    "session": "@{body('Get_API_Token')?['value']}"
                                                 },
                                                 "method": "POST",
-                                                "uri": "@parameters('TaniumApiGatewayApi')"
+                                                "uri": "@uri(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumApiGatewayPath')))"
                                             },
                                             "runtimeConfiguration": {
                                                 "secureData": {
@@ -887,7 +883,7 @@
                                         ]
                                     }
                                 },
-                                "Get_secret": {
+                                "Get_API_Token": {
                                     "type": "ApiConnection",
                                     "inputs": {
                                         "host": {
@@ -897,6 +893,26 @@
                                         },
                                         "method": "get",
                                         "path": "/secrets/@{encodeURIComponent('TaniumApiToken')}/value"
+                                    },
+                                    "runtimeConfiguration": {
+                                        "secureData": {
+                                            "properties": [
+                                                "inputs",
+                                                "outputs"
+                                            ]
+                                        }
+                                    }
+                                },
+                                "Get_Server_Host": {
+                                    "type": "ApiConnection",
+                                    "inputs": {
+                                        "host": {
+                                            "connection": {
+                                                "name": "@parameters('$connections')['keyvault-1']['connectionId']"
+                                            }
+                                        },
+                                        "method": "get",
+                                        "path": "/secrets/@{encodeURIComponent('TaniumServerHostname')}/value"
                                     },
                                     "runtimeConfiguration": {
                                         "secureData": {
@@ -982,8 +998,8 @@
                             }
                         }
                     },
-                    "TaniumApiGatewayApi": {
-                        "value": "[variables('TaniumApiGatewayApi')]"
+                    "TaniumApiGatewayPath": {
+                        "value": "[variables('TaniumApiGatewayPath')]"
                     }
                 }
             }

--- a/Solutions/Tanium/Playbooks/Tanium-GeneralHostInfo/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-GeneralHostInfo/azuredeploy.json
@@ -59,17 +59,10 @@
             "metadata": {
                 "description": "The resource group name for the existing Azure Integration Account"
             }
-        },       
-        "TaniumServerHostname": {
-            "defaultValue": "<customerName>-api.cloud.tanium.com",
-            "type": "String",
-            "metadata": {
-                "description": "The hostname for your Tanium server's API. For cloud customers use <customerName>-api.cloud.tanium.com. For on-prem use the hostname of your server."
-            }
         }
     },
     "variables": {
-        "TaniumApiGatewayApi": "[uri(concat('https://',parameters('TaniumServerHostname')),'/plugin/products/gateway/graphql')]"
+        "TaniumApiGatewayPath": "/plugin/products/gateway/graphql"
     },
     "resources": [
         {
@@ -94,14 +87,14 @@
             "location": "[resourceGroup().location]",
             "kind": "V1",
             "properties": {
-                "displayName": "[parameters('KeyVaultConnectionName')]",                
+                "displayName": "[parameters('KeyVaultConnectionName')]",
                 "customParameterValues": {},
-                "api": {                    
+                "api": {
                     "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/keyvault')]"
                 },
                 "parameterValueType": "Alternative",
-                "alternativeParameterValues": {  
-                    "vaultName": "[parameters('KeyVaultName')]"  
+                "alternativeParameterValues": {
+                    "vaultName": "[parameters('KeyVaultName')]"
                 }
             }
         },
@@ -133,7 +126,7 @@
                             "defaultValue": {},
                             "type": "Object"
                         },
-                        "TaniumApiGatewayApi": {
+                        "TaniumApiGatewayPath": {
                             "type": "String"
                         }
                     },
@@ -502,10 +495,10 @@
                                                         },
                                                         "headers": {
                                                             "Content-Type": "application/json",
-                                                            "session": "@{body('Get_secret')?['value']}"
+                                                            "session": "@{body('Get_API_Token')?['value']}"
                                                         },
                                                         "method": "POST",
-                                                        "uri": "@parameters('TaniumApiGatewayApi')"
+                                                        "uri": "@uri(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumApiGatewayPath')))"
                                                     },
                                                     "runtimeConfiguration": {
                                                         "secureData": {
@@ -716,13 +709,16 @@
                                         },
                                         "headers": {
                                             "Content-Type": "application/json",
-                                            "session": "@{body('Get_secret')?['value']}"
+                                            "session": "@{body('Get_API_Token')?['value']}"
                                         },
                                         "method": "POST",
-                                        "uri": "@parameters('TaniumApiGatewayApi')"
+                                        "uri": "@uri(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumApiGatewayPath')))"
                                     },
                                     "runAfter": {
-                                        "Get_secret": [
+                                        "Get_API_Token": [
+                                            "SUCCEEDED"
+                                        ],
+                                        "Get_Server_Host": [
                                             "SUCCEEDED"
                                         ]
                                     },
@@ -750,10 +746,10 @@
                                                 },
                                                 "headers": {
                                                     "Content-Type": "application/json",
-                                                    "session": "@{body('Get_secret')?['value']}"
+                                                    "session": "@{body('Get_API_Token')?['value']}"
                                                 },
                                                 "method": "POST",
-                                                "uri": "@parameters('TaniumApiGatewayApi')"
+                                                "uri": "@uri(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumApiGatewayPath')))"
                                             },
                                             "runtimeConfiguration": {
                                                 "secureData": {
@@ -856,7 +852,7 @@
                                         ]
                                     }
                                 },
-                                "Get_secret": {
+                                "Get_API_Token": {
                                     "type": "ApiConnection",
                                     "inputs": {
                                         "host": {
@@ -866,6 +862,26 @@
                                         },
                                         "method": "get",
                                         "path": "/secrets/@{encodeURIComponent('TaniumApiToken')}/value"
+                                    },
+                                    "runtimeConfiguration": {
+                                        "secureData": {
+                                            "properties": [
+                                                "inputs",
+                                                "outputs"
+                                            ]
+                                        }
+                                    }
+                                },
+                                "Get_Server_Host": {
+                                    "type": "ApiConnection",
+                                    "inputs": {
+                                        "host": {
+                                            "connection": {
+                                                "name": "@parameters('$connections')['keyvault-1']['connectionId']"
+                                            }
+                                        },
+                                        "method": "get",
+                                        "path": "/secrets/@{encodeURIComponent('TaniumServerHostname')}/value"
                                     },
                                     "runtimeConfiguration": {
                                         "secureData": {
@@ -936,8 +952,8 @@
                             }
                         }
                     },
-                    "TaniumApiGatewayApi": {
-                        "value": "[variables('TaniumApiGatewayApi')]"
+                    "TaniumApiGatewayPath": {
+                        "value": "[variables('TaniumApiGatewayPath')]"
                     }
                 }
             }

--- a/Solutions/Tanium/Playbooks/Tanium-MSDefenderHealth/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-MSDefenderHealth/azuredeploy.json
@@ -56,17 +56,10 @@
             "metadata": {
                 "description": "The resource group name for the existing Azure Integration Account"
             }
-        },
-        "TaniumServerHostname": {
-            "defaultValue": "<customerName>-api.cloud.tanium.com",
-            "type": "String",
-            "metadata": {
-                "description": "The hostname for your Tanium server's API. For cloud customers use <customerName>-api.cloud.tanium.com. For on-prem use the hostname of your server."
-            }
         }
     },
     "variables": {
-        "TaniumApiGatewayApi": "[uri(concat('https://',parameters('TaniumServerHostname')),'/plugin/products/gateway/graphql')]"
+        "TaniumApiGatewayPath": "/plugin/products/gateway/graphql"
     },
     "resources": [
         {
@@ -129,7 +122,7 @@
                             "defaultValue": {},
                             "type": "Object"
                         },
-                        "TaniumApiGatewayApi": {
+                        "TaniumApiGatewayPath": {
                             "type": "String"
                         }
                     },
@@ -473,10 +466,10 @@
                                                         },
                                                         "headers": {
                                                             "Content-Type": "application/json",
-                                                            "session": "@{body('Get_secret')?['value']}"
+                                                            "session": "@{body('Get_API_Token')?['value']}"
                                                         },
                                                         "method": "POST",
-                                                        "uri": "@parameters('TaniumApiGatewayApi')"
+                                                        "uri": "@uri(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumApiGatewayPath')))"
                                                     },
                                                     "runtimeConfiguration": {
                                                         "secureData": {
@@ -687,13 +680,16 @@
                                         },
                                         "headers": {
                                             "Content-Type": "application/json",
-                                            "session": "@{body('Get_secret')?['value']}"
+                                            "session": "@{body('Get_API_Token')?['value']}"
                                         },
                                         "method": "POST",
-                                        "uri": "@parameters('TaniumApiGatewayApi')"
+                                        "uri": "@uri(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumApiGatewayPath')))"
                                     },
                                     "runAfter": {
-                                        "Get_secret": [
+                                        "Get_API_Token": [
+                                            "SUCCEEDED"
+                                        ],
+                                        "Get_Server_Host": [
                                             "SUCCEEDED"
                                         ]
                                     },
@@ -721,10 +717,10 @@
                                                 },
                                                 "headers": {
                                                     "Content-Type": "application/json",
-                                                    "session": "@{body('Get_secret')?['value']}"
+                                                    "session": "@{body('Get_API_Token')?['value']}"
                                                 },
                                                 "method": "POST",
-                                                "uri": "@parameters('TaniumApiGatewayApi')"
+                                                "uri": "@uri(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumApiGatewayPath')))"
                                             },
                                             "runtimeConfiguration": {
                                                 "secureData": {
@@ -815,7 +811,7 @@
                                         ]
                                     }
                                 },
-                                "Get_secret": {
+                                "Get_API_Token": {
                                     "type": "ApiConnection",
                                     "inputs": {
                                         "host": {
@@ -825,6 +821,26 @@
                                         },
                                         "method": "get",
                                         "path": "/secrets/@{encodeURIComponent('TaniumApiToken')}/value"
+                                    },
+                                    "runtimeConfiguration": {
+                                        "secureData": {
+                                            "properties": [
+                                                "inputs",
+                                                "outputs"
+                                            ]
+                                        }
+                                    }
+                                },
+                                "Get_Server_Host": {
+                                    "type": "ApiConnection",
+                                    "inputs": {
+                                        "host": {
+                                            "connection": {
+                                                "name": "@parameters('$connections')['keyvault-1']['connectionId']"
+                                            }
+                                        },
+                                        "method": "get",
+                                        "path": "/secrets/@{encodeURIComponent('TaniumServerHostname')}/value"
                                     },
                                     "runtimeConfiguration": {
                                         "secureData": {
@@ -932,8 +948,8 @@
                             }
                         }
                     },
-                    "TaniumApiGatewayApi": {
-                        "value": "[variables('TaniumApiGatewayApi')]"
+                    "TaniumApiGatewayPath": {
+                        "value": "[variables('TaniumApiGatewayPath')]"
                     }
                 }
             }

--- a/Solutions/Tanium/Playbooks/Tanium-QuarantineHosts/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-QuarantineHosts/azuredeploy.json
@@ -57,21 +57,14 @@
             "metadata": {
                 "description": "The resource group name for the existing Azure Integration Account"
             }
-        },
-        "TaniumServerHostname": {
-            "defaultValue": "<customerName>-api.cloud.tanium.com",
-            "type": "String",
-            "metadata": {
-                "description": "The hostname for your Tanium server's API. For cloud customers use <customerName>-api.cloud.tanium.com. For on-prem use the hostname of your server."
-            }
         }
     },
     "variables": {
-        "TaniumActionsApi": "[uri(concat('https://', parameters('TaniumServerHostname')), '/api/v2/actions')]",
-        "TaniumAllComputersUrl": "[uri(concat('https://', parameters('TaniumServerHostname')), '/api/v2/groups/by-name/All%20Computers')]",
-        "TaniumPackagesByNameUrlFragment": "[uri(concat('https://', parameters('TaniumServerHostname')), '/api/v2/packages/by-name/')]",
-        "TaniumActionResultDataUrlFragment": "[uri(concat('https://', parameters('TaniumServerHostname')), '/api/v2/result_data/action/')]",
-        "TaniumApiGatewayApi": "[uri(concat('https://', parameters('TaniumServerHostname')), '/plugin/products/gateway/graphql')]"
+        "TaniumActionsPath": "/api/v2/actions",
+        "TaniumAllComputersPath": "/api/v2/groups/by-name/All%20Computers",
+        "TaniumPackagesByNamePath": "/api/v2/packages/by-name/",
+        "TaniumActionResultPath": "/api/v2/result_data/action/",
+        "TaniumApiGatewayPath": "/plugin/products/gateway/graphql"
     },
     "resources": [
         {
@@ -108,7 +101,7 @@
         },
         {
             "type": "Microsoft.Logic/workflows",
-            "apiVersion": "2019-05-01",
+            "apiVersion": "2017-07-01",
             "name": "[parameters('PlaybookName')]",
             "location": "[resourceGroup().location]",
             "identity": {
@@ -134,19 +127,19 @@
                             "defaultValue": {},
                             "type": "Object"
                         },
-                        "TaniumActionsApi": {
+                        "TaniumActionsPath": {
                             "type": "String"
                         },
-                        "TaniumAllComputersUrl": {
+                        "TaniumAllComputersPath": {
                             "type": "String"
                         },
-                        "TaniumPackagesByNameUrlFragment": {
+                        "TaniumPackagesByNamePath": {
                             "type": "String"
                         },
-                        "TaniumActionResultDataUrlFragment": {
+                        "TaniumActionResultPath": {
                             "type": "String"
                         },
-                        "TaniumApiGatewayApi": {
+                        "TaniumApiGatewayPath": {
                             "type": "String"
                         }
                     },
@@ -364,10 +357,10 @@
                             "inputs": {
                                 "headers": {
                                     "Content-Type": "application/json",
-                                    "session": "@{body('Get_secret')?['value']}"
+                                    "session": "@{body('Get_API_Token')?['value']}"
                                 },
                                 "method": "GET",
-                                "uri": "@parameters('TaniumAllComputersUrl')"
+                                "uri": "@uri(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumAllComputersPath')))"
                             },
                             "runtimeConfiguration": {
                                 "secureData": {
@@ -457,10 +450,10 @@
                                     "inputs": {
                                         "headers": {
                                             "Content-Type": "application/json",
-                                            "session": "@{body('Get_secret')?['value']}"
+                                            "session": "@{body('Get_API_Token')?['value']}"
                                         },
                                         "method": "GET",
-                                        "uri": "@{concat(parameters('TaniumPackagesByNameUrlFragment'), join(split(variables('linuxPackageName'), ' '), '%20'))}"
+                                        "uri": "@{concat(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumPackagesByNamePath')), join(split(variables('linuxPackageName'), ' '), '%20'))}"
                                     },
                                     "runtimeConfiguration": {
                                         "secureData": {
@@ -481,10 +474,10 @@
                                         "body": "@outputs('Compose_Linux_action')",
                                         "headers": {
                                             "Content-Type": "application/json",
-                                            "session": "@{body('Get_secret')?['value']}"
+                                            "session": "@{body('Get_API_Token')?['value']}"
                                         },
                                         "method": "POST",
-                                        "uri": "@parameters('TaniumActionsApi')"
+                                        "uri": "@uri(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumActionsPath')))"
                                     },
                                     "runtimeConfiguration": {
                                         "secureData": {
@@ -712,10 +705,10 @@
                                     "inputs": {
                                         "headers": {
                                             "Content-Type": "application/json",
-                                            "session": "@{body('Get_secret')?['value']}"
+                                            "session": "@{body('Get_API_Token')?['value']}"
                                         },
                                         "method": "GET",
-                                        "uri": "@{concat(parameters('TaniumPackagesByNameUrlFragment'), join(split(variables('windowsPackageName'), ' '), '%20'))}"
+                                        "uri": "@{concat(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumPackagesByNamePath')), join(split(variables('windowsPackageName'), ' '), '%20'))}"
                                     },
                                     "runtimeConfiguration": {
                                         "secureData": {
@@ -736,10 +729,10 @@
                                         "body": "@outputs('Compose_windows_action')",
                                         "headers": {
                                             "Content-Type": "application/json",
-                                            "session": "@{body('Get_secret')?['value']}"
+                                            "session": "@{body('Get_API_Token')?['value']}"
                                         },
                                         "method": "POST",
-                                        "uri": "@parameters('TaniumActionsApi')"
+                                        "uri": "@uri(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumActionsPath')))"
                                     },
                                     "runtimeConfiguration": {
                                         "secureData": {
@@ -967,10 +960,10 @@
                                     "inputs": {
                                         "headers": {
                                             "Content-Type": "application/json",
-                                            "session": "@{body('Get_secret')?['value']}"
+                                            "session": "@{body('Get_API_Token')?['value']}"
                                         },
                                         "method": "GET",
-                                        "uri": "@{concat(parameters('TaniumPackagesByNameUrlFragment'), join(split(variables('macOsPackageName'), ' '), '%20'))}"
+                                        "uri": "@{concat(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumPackagesByNamePath')), join(split(variables('macOsPackageName'), ' '), '%20'))}"
                                     },
                                     "runtimeConfiguration": {
                                         "secureData": {
@@ -991,10 +984,10 @@
                                         "body": "@outputs('Compose_macOS_action')",
                                         "headers": {
                                             "Content-Type": "application/json",
-                                            "session": "@{body('Get_secret')?['value']}"
+                                            "session": "@{body('Get_API_Token')?['value']}"
                                         },
                                         "method": "POST",
-                                        "uri": "@parameters('TaniumActionsApi')"
+                                        "uri": "@uri(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumActionsPath')))"
                                     },
                                     "runtimeConfiguration": {
                                         "secureData": {
@@ -1446,9 +1439,9 @@
                                         },
                                         "headers": {
                                             "Content-Type": "application/json",
-                                            "session": "@{body('Get_secret')?['value']}"
+                                            "session": "@{body('Get_API_Token')?['value']}"
                                         },
-                                        "uri": "@parameters('TaniumApiGatewayApi')",
+                                        "uri": "@uri(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumApiGatewayPath')))",
                                         "method": "POST"
                                     },
                                     "runtimeConfiguration": {
@@ -1488,10 +1481,10 @@
                                                 },
                                                 "headers": {
                                                     "Content-Type": "application/json",
-                                                    "session": "@{body('Get_secret')?['value']}"
+                                                    "session": "@{body('Get_API_Token')?['value']}"
                                                 },
                                                 "method": "POST",
-                                                "uri": "@parameters('TaniumApiGatewayApi')"
+                                                "uri": "@uri(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumApiGatewayPath')))"
                                             },
                                             "runtimeConfiguration": {
                                                 "secureData": {
@@ -1735,11 +1728,11 @@
                                                     },
                                                     "type": "Http",
                                                     "inputs": {
-                                                        "uri": "@parameters('TaniumApiGatewayApi')",
+                                                        "uri": "@uri(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumApiGatewayPath')))",
                                                         "method": "POST",
                                                         "headers": {
                                                             "Content-Type": "application/json",
-                                                            "session": "@{body('Get_secret')?['value']}"
+                                                            "session": "@{body('Get_API_Token')?['value']}"
                                                         },
                                                         "body": {
                                                             "query": "@variables('apiQuery')",
@@ -1926,7 +1919,10 @@
                                 }
                             },
                             "runAfter": {
-                                "Get_secret": [
+                                "Get_API_Token": [
+                                    "SUCCEEDED"
+                                ],
+                                "Get_Server_Host": [
                                     "SUCCEEDED"
                                 ]
                             }
@@ -2149,11 +2145,11 @@
                                         "Get_action_result": {
                                             "type": "Http",
                                             "inputs": {
-                                                "uri": "@{concat(parameters('TaniumActionResultDataUrlFragment'), items('Collect_action_results_for_each_issued_action')?['id'])}",
+                                                "uri": "@{concat(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumActionResultPath')), items('Collect_action_results_for_each_issued_action')?['id'])}",
                                                 "method": "GET",
                                                 "headers": {
                                                     "Content-Type": "application/json",
-                                                    "session": "@{body('Get_secret')?['value']}"
+                                                    "session": "@{body('Get_API_Token')?['value']}"
                                                 },
                                                 "runtimeConfiguration": {
                                                     "secureData": {
@@ -2631,7 +2627,7 @@
                                 ]
                             }
                         },
-                        "Get_secret": {
+                        "Get_API_Token": {
                             "type": "ApiConnection",
                             "inputs": {
                                 "host": {
@@ -2641,6 +2637,40 @@
                                 },
                                 "method": "get",
                                 "path": "/secrets/@{encodeURIComponent('TaniumApiToken')}/value"
+                            },
+                            "runtimeConfiguration": {
+                                "secureData": {
+                                    "properties": [
+                                        "inputs",
+                                        "outputs"
+                                    ]
+                                }
+                            },
+                            "runAfter": {
+                                "Initialize_API_Query": [
+                                    "Succeeded"
+                                ],
+                                "Initialize_endpoints_array": [
+                                    "Succeeded"
+                                ],
+                                "Initialize_API_Variables": [
+                                    "Succeeded"
+                                ],
+                                "Initialize_cursor": [
+                                    "Succeeded"
+                                ]
+                            }
+                        },
+                        "Get_Server_Host": {
+                            "type": "ApiConnection",
+                            "inputs": {
+                                "host": {
+                                    "connection": {
+                                        "name": "@parameters('$connections')['keyvault-1']['connectionId']"
+                                    }
+                                },
+                                "method": "get",
+                                "path": "/secrets/@{encodeURIComponent('TaniumServerHostname')}/value"
                             },
                             "runtimeConfiguration": {
                                 "secureData": {
@@ -2694,20 +2724,20 @@
                             }
                         }
                     },
-                    "TaniumActionsApi": {
-                        "value": "[variables('TaniumActionsApi')]"
+                    "TaniumActionsPath": {
+                        "value": "[variables('TaniumActionsPath')]"
                     },
-                    "TaniumAllComputersUrl": {
-                        "value": "[variables('TaniumAllComputersUrl')]"
+                    "TaniumAllComputersPath2": {
+                        "value": "[variables('TaniumAllComputersPath')]"
                     },
-                    "TaniumPackagesByNameUrlFragment": {
-                        "value": "[variables('TaniumPackagesByNameUrlFragment')]"
+                    "TaniumPackagesByNamePath": {
+                        "value": "[variables('TaniumPackagesByNamePath')]"
                     },
-                    "TaniumActionResultDataUrlFragment": {
-                        "value": "[variables('TaniumActionResultDataUrlFragment')]"
+                    "TaniumActionResultPath": {
+                        "value": "[variables('TaniumActionResultPath')]"
                     },
-                    "TaniumApiGatewayApi": {
-                        "value": "[variables('TaniumApiGatewayApi')]"
+                    "TaniumApiGatewayPath": {
+                        "value": "[variables('TaniumApiGatewayPath')]"
                     }
                 }
             }

--- a/Solutions/Tanium/Playbooks/Tanium-ResolveThreatResponseAlert/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-ResolveThreatResponseAlert/azuredeploy.json
@@ -57,17 +57,10 @@
       "metadata": {
         "description": "The resource group name for the existing Azure Integration Account"
       }
-    },
-    "TaniumServerHostname": {
-      "defaultValue": "hostname",
-      "type": "String",
-      "metadata": {
-        "description": "The hostname for your Tanium server e.g. tanium.example.com"
-      }
     }
   },
   "variables": {
-    "TaniumApiGatewayApi": "[uri(concat('https://',parameters('TaniumServerHostname')),'/plugin/products/gateway/graphql')]"
+    "TaniumApiGatewayPath": "/plugin/products/gateway/graphql"
   },
   "resources": [
     {
@@ -130,7 +123,7 @@
               "defaultValue": {},
               "type": "Object"
             },
-            "TaniumApiGatewayApi": {
+             "TaniumApiGatewayPath": {
               "type": "String"
             }
           },
@@ -234,7 +227,7 @@
             "Initialize_API_Variables": {
               "runAfter": {
                 "Extract_Threat_Response_Alert_GUID": [
-                  "Succeeded"
+                  "SUCCEEDED"
                 ]
               },
               "type": "InitializeVariable",
@@ -250,7 +243,10 @@
             },
             "Resolve_Threat_Response_Alert": {
               "runAfter": {
-                "Get_secret": [
+                "Get_API_Token": [
+                  "Succeeded"
+                ],
+                "Get_Server_Host": [
                   "SUCCEEDED"
                 ]
               },
@@ -263,13 +259,13 @@
                 },
                 "headers": {
                   "Content-Type": "application/json",
-                  "session": "@{body('Get_secret')?['value']}"
+                  "session": "@{body('Get_API_Token')?['value']}"
                 },
                 "method": "POST",
-                "uri": "@parameters('TaniumApiGatewayApi')"
-              }
+                "uri": "@uri(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumApiGatewayPath')))"
+              }              
             },
-            "Get_secret": {
+            "Get_API_Token": {
               "type": "ApiConnection",
               "inputs": {
                 "host": {
@@ -279,6 +275,34 @@
                 },
                 "method": "get",
                 "path": "/secrets/@{encodeURIComponent('TaniumApiToken')}/value"
+              },
+              "runAfter": {
+                "Initialize_API_Mutation": [
+                  "SUCCEEDED"
+                ],
+                "Initialize_API_Variables": [
+                  "SUCCEEDED"
+                ]
+              },
+              "runtimeConfiguration": {
+                "secureData": {
+                  "properties": [
+                    "inputs",
+                    "outputs"
+                  ]
+                }
+              }
+            },
+            "Get_Server_Host": {
+              "type": "ApiConnection",
+              "inputs": {
+                "host": {
+                  "connection": {
+                    "name": "@parameters('$connections')['keyvault-1']['connectionId']"
+                  }
+                },
+                "method": "get",
+                "path": "/secrets/@{encodeURIComponent('TaniumServerHostname')}/value"
               },
               "runAfter": {
                 "Initialize_API_Variables": [
@@ -326,8 +350,8 @@
               }
             }
           },
-          "TaniumApiGatewayApi": {
-            "value": "[variables('TaniumApiGatewayApi')]"
+          "TaniumApiGatewayPath": {
+            "value": "[variables('TaniumApiGatewayPath')]"
           }
         }
       }

--- a/Solutions/Tanium/Playbooks/Tanium-SCCMClientHealth/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-SCCMClientHealth/azuredeploy.json
@@ -56,17 +56,10 @@
             "metadata": {
                 "description": "The resource group name for the existing Azure Integration Account"
             }
-        },
-        "TaniumServerHostname": {
-            "defaultValue": "<customerName>-api.cloud.tanium.com",
-            "type": "String",
-            "metadata": {
-                "description": "The hostname for your Tanium server's API. For cloud customers use <customerName>-api.cloud.tanium.com. For on-prem use the hostname of your server."
-            }
         }
     },
     "variables": {
-        "TaniumApiGatewayApi": "[uri(concat('https://',parameters('TaniumServerHostname')),'/plugin/products/gateway/graphql')]"
+        "TaniumApiGatewayPath": "/plugin/products/gateway/graphql"
     },
     "resources": [
         {
@@ -129,7 +122,7 @@
                             "defaultValue": {},
                             "type": "Object"
                         },                       
-                        "TaniumApiGatewayApi": {
+                        "TaniumApiGatewayPath": {
                             "type": "String"
                         }
                     },
@@ -473,10 +466,10 @@
                                                         },
                                                         "headers": {
                                                             "Content-Type": "application/json",
-                                                            "session": "@{body('Get_secret')?['value']}"
+                                                            "session": "@{body('Get_API_Token')?['value']}"
                                                         },
                                                         "method": "POST",
-                                                        "uri": "@parameters('TaniumApiGatewayApi')"
+                                                        "uri": "@uri(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumApiGatewayPath')))"
                                                     },
                                                     "runtimeConfiguration": {
                                                         "secureData": {
@@ -687,15 +680,18 @@
                                         },
                                         "headers": {
                                             "Content-Type": "application/json",
-                                            "session": "@{body('Get_secret')?['value']}"
+                                            "session": "@{body('Get_API_Token')?['value']}"
                                         },
                                         "method": "POST",
-                                        "uri": "@parameters('TaniumApiGatewayApi')"
+                                        "uri": "@uri(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumApiGatewayPath')))"
                                     },
                                      "runAfter": {
-                                        "Get_secret": [
+                                        "Get_API_Token": [
                                             "SUCCEEDED"
-                                         ]
+                                         ],
+                                        "Get_Server_Host": [
+                                            "SUCCEEDED"
+                                        ]
                                     },
                                     "runtimeConfiguration": {
                                         "secureData": {
@@ -721,10 +717,10 @@
                                                 },
                                                 "headers": {
                                                     "Content-Type": "application/json",
-                                                    "session": "@{body('Get_secret')?['value']}"
+                                                    "session": "@{body('Get_API_Token')?['value']}"
                                                 },
                                                 "method": "POST",
-                                                "uri": "@parameters('TaniumApiGatewayApi')"
+                                                "uri": "@uri(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumApiGatewayPath')))"
                                             },
                                             "runtimeConfiguration": {
                                                 "secureData": {
@@ -815,7 +811,7 @@
                                         ]
                                     }
                                 },
-                                "Get_secret": {
+                                "Get_API_Token": {
                                     "type": "ApiConnection",
                                     "inputs": {
                                         "host": {
@@ -834,6 +830,26 @@
                                             ]
                                         }
                                      }
+                                },
+                                "Get_Server_Host": {
+                                    "type": "ApiConnection",
+                                    "inputs": {
+                                        "host": {
+                                            "connection": {
+                                                "name": "@parameters('$connections')['keyvault-1']['connectionId']"
+                                            }
+                                        },
+                                        "method": "get",
+                                        "path": "/secrets/@{encodeURIComponent('TaniumServerHostname')}/value"
+                                    },
+                                    "runtimeConfiguration": {
+                                        "secureData": {
+                                            "properties": [
+                                                "inputs",
+                                                "outputs"
+                                            ]
+                                        }
+                                    }
                                 }
                             },
                             "runAfter": {
@@ -932,8 +948,8 @@
                             }
                         }
                     },                    
-                    "TaniumApiGatewayApi": {
-                        "value": "[variables('TaniumApiGatewayApi')]"
+                    "TaniumApiGatewayPath": {
+                        "value": "[variables('TaniumApiGatewayPath')]"
                     }
                 }
             }

--- a/Solutions/Tanium/Playbooks/Tanium-SecurityPatches/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-SecurityPatches/azuredeploy.json
@@ -57,17 +57,10 @@
             "metadata": {
                 "description": "The resource group name for the existing Azure Integration Account"
             }
-        },
-        "TaniumServerHostname": {
-            "defaultValue": "<customerName>-api.cloud.tanium.com",
-            "type": "String",
-            "metadata": {
-                "description": "The hostname for your Tanium server's API. For cloud customers use <customerName>-api.cloud.tanium.com. For on-prem use the hostname of your server."
-            }
         }
     },
     "variables": {
-        "TaniumApiGatewayApi": "[uri(concat('https://',parameters('TaniumServerHostname')),'/plugin/products/gateway/graphql')]"
+        "TaniumApiGatewayPath": "/plugin/products/gateway/graphql"
     },
     "resources": [
         {
@@ -130,7 +123,7 @@
                             "defaultValue": {},
                             "type": "Object"
                         },
-                        "TaniumApiGatewayApi": {
+                        "TaniumApiGatewayPath": {
                             "type": "String"
                         }
                     },
@@ -792,10 +785,10 @@
                                                         },
                                                         "headers": {
                                                             "Content-Type": "application/json",
-                                                            "session": "@{body('Get_secret')?['value']}"
+                                                            "session": "@{body('Get_API_Token')?['value']}"
                                                         },
                                                         "method": "POST",
-                                                        "uri": "@parameters('TaniumApiGatewayApi')"
+                                                        "uri": "@uri(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumApiGatewayPath')))"
                                                     },
                                                     "runtimeConfiguration": {
                                                         "secureData": {
@@ -1094,10 +1087,10 @@
                                                 },
                                                 "headers": {
                                                     "Content-Type": "application/json",
-                                                    "session": "@{body('Get_secret')?['value']}"
+                                                    "session": "@{body('Get_API_Token')?['value']}"
                                                 },
                                                 "method": "POST",
-                                                "uri": "@parameters('TaniumApiGatewayApi')"
+                                                "uri": "@uri(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumApiGatewayPath')))"
                                             },
                                             "runtimeConfiguration": {
                                                 "secureData": {
@@ -1115,7 +1108,10 @@
                                     },
                                     "type": "Until",
                                     "runAfter": {
-                                        "Get_secret": [
+                                        "Get_API_Token": [
+                                            "SUCCEEDED"
+                                        ],
+                                        "Get_Server_Host": [
                                             "SUCCEEDED"
                                         ]
                                     }
@@ -1189,11 +1185,11 @@
                                                     "Refresh_API_Gateway_query": {
                                                         "type": "Http",
                                                         "inputs": {
-                                                            "uri": "@parameters('TaniumApiGatewayApi')",
+                                                            "uri": "@uri(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumApiGatewayPath')))",
                                                             "method": "POST",
                                                             "headers": {
                                                                 "Content-Type": "application/json",
-                                                                "session": "@{body('Get_secret')?['value']}"
+                                                                "session": "@{body('Get_API_Token')?['value']}"
                                                             },
                                                             "body": {
                                                                 "query": "@variables('apiQuery')",
@@ -1269,7 +1265,7 @@
                                         ]
                                     }
                                 },
-                                "Get_secret": {
+                                "Get_API_Token": {
                                     "type": "ApiConnection",
                                     "inputs": {
                                         "host": {
@@ -1279,6 +1275,26 @@
                                         },
                                         "method": "get",
                                         "path": "/secrets/@{encodeURIComponent('TaniumApiToken')}/value"
+                                    },
+                                    "runtimeConfiguration": {
+                                        "secureData": {
+                                            "properties": [
+                                                "inputs",
+                                                "outputs"
+                                            ]
+                                        }
+                                    }
+                                },
+                                "Get_Server_Host": {
+                                    "type": "ApiConnection",
+                                    "inputs": {
+                                        "host": {
+                                            "connection": {
+                                                "name": "@parameters('$connections')['keyvault-1']['connectionId']"
+                                            }
+                                        },
+                                        "method": "get",
+                                        "path": "/secrets/@{encodeURIComponent('TaniumServerHostname')}/value"
                                     },
                                     "runtimeConfiguration": {
                                         "secureData": {
@@ -1371,13 +1387,13 @@
                                 "connectionProperties": {
                                     "authentication": {
                                         "type": "ManagedServiceIdentity"
-                                     }
+                                    }
                                 }
                             }
                         }
                     },
-                    "TaniumApiGatewayApi": {
-                        "value": "[variables('TaniumApiGatewayApi')]"
+                    "TaniumApiGatewayPath": {
+                        "value": "[variables('TaniumApiGatewayPath')]"
                     }
                 }
             }

--- a/Solutions/Tanium/Playbooks/Tanium-UnquarantineHosts/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-UnquarantineHosts/azuredeploy.json
@@ -56,21 +56,14 @@
             "metadata": {
                 "description": "The resource group name for the existing Azure Integration Account"
             }
-        },
-        "TaniumServerHostname": {
-            "defaultValue": "<customerName>-api.cloud.tanium.com",
-            "type": "String",
-            "metadata": {
-                "description": "The hostname for your Tanium server's API. For cloud customers use <customerName>-api.cloud.tanium.com. For on-prem use the hostname of your server."
-            }
         }
     },
     "variables": {
-        "TaniumActionsApi": "[uri(concat('https://', parameters('TaniumServerHostname')), '/api/v2/actions')]",
-        "TaniumAllComputersUrl": "[uri(concat('https://', parameters('TaniumServerHostname')), '/api/v2/groups/by-name/All%20Computers')]",
-        "TaniumPackagesByNameUrlFragment": "[uri(concat('https://', parameters('TaniumServerHostname')), '/api/v2/packages/by-name/')]",
-        "TaniumActionResultDataUrlFragment": "[uri(concat('https://', parameters('TaniumServerHostname')), '/api/v2/result_data/action/')]",
-        "TaniumApiGatewayApi": "[uri(concat('https://', parameters('TaniumServerHostname')), '/plugin/products/gateway/graphql')]"
+        "TaniumActionsPath": "/api/v2/actions",
+        "TaniumAllComputersPath": "/api/v2/groups/by-name/All%20Computers",
+        "TaniumPackagesByNamePath": "/api/v2/packages/by-name/",
+        "TaniumActionResultPath": "/api/v2/result_data/action/",
+        "TaniumApiGatewayPath": "/plugin/products/gateway/graphql"
     },
     "resources": [
         {
@@ -107,7 +100,7 @@
         },
         {
             "type": "Microsoft.Logic/workflows",
-            "apiVersion": "2016-06-01",
+            "apiVersion": "2017-07-01",
             "name": "[parameters('PlaybookName')]",
             "location": "[resourceGroup().location]",
             "identity": {
@@ -133,19 +126,19 @@
                             "defaultValue": {},
                             "type": "Object"
                         },
-                        "TaniumActionsApi": {
+                        "TaniumActionsPath": {
                             "type": "String"
                         },
-                        "TaniumAllComputersUrl": {
+                        "TaniumAllComputersPath": {
                             "type": "String"
                         },
-                        "TaniumPackagesByNameUrlFragment": {
+                        "TaniumPackagesByNamePath": {
                             "type": "String"
                         },
-                        "TaniumActionResultDataUrlFragment": {
+                        "TaniumActionResultPath": {
                             "type": "String"
                         },
-                        "TaniumApiGatewayApi": {
+                        "TaniumApiGatewayPath": {
                             "type": "String"
                         }
                     },
@@ -362,10 +355,10 @@
                             "inputs": {
                                 "headers": {
                                     "Content-Type": "application/json",
-                                    "session": "@{body('Get_secret')?['value']}"
+                                    "session": "@{body('Get_API_Token')?['value']}"
                                 },
                                 "method": "GET",
-                                "uri": "@parameters('TaniumAllComputersUrl')"
+                                "uri": "@uri(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumAllComputersPath')))"
                             },
                             "runtimeConfiguration": {
                                 "secureData": {
@@ -455,10 +448,10 @@
                                     "inputs": {
                                         "headers": {
                                             "Content-Type": "application/json",
-                                            "session": "@{body('Get_secret')?['value']}"
+                                            "session": "@{body('Get_API_Token')?['value']}"
                                         },
                                         "method": "GET",
-                                        "uri": "@{concat(parameters('TaniumPackagesByNameUrlFragment'), join(split(variables('linuxPackageName'), ' '), '%20'))}"
+                                        "uri": "@{concat(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumPackagesByNamePath')), join(split(variables('linuxPackageName'), ' '), '%20'))}"
                                     },
                                     "runtimeConfiguration": {
                                         "secureData": {
@@ -479,10 +472,10 @@
                                         "body": "@outputs('Compose_Linux_action')",
                                         "headers": {
                                             "Content-Type": "application/json",
-                                            "session": "@{body('Get_secret')?['value']}"
+                                            "session": "@{body('Get_API_Token')?['value']}"
                                         },
                                         "method": "POST",
-                                        "uri": "@parameters('TaniumActionsApi')"
+                                        "uri": "@uri(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumActionsPath')))"
                                     },
                                     "runtimeConfiguration": {
                                         "secureData": {
@@ -710,10 +703,10 @@
                                     "inputs": {
                                         "headers": {
                                             "Content-Type": "application/json",
-                                            "session": "@{body('Get_secret')?['value']}"
+                                            "session": "@{body('Get_API_Token')?['value']}"
                                         },
                                         "method": "GET",
-                                        "uri": "@{concat(parameters('TaniumPackagesByNameUrlFragment'), join(split(variables('windowsPackageName'), ' '), '%20'))}"
+                                        "uri": "@{concat(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumPackagesByNamePath')), join(split(variables('windowsPackageName'), ' '), '%20'))}"
                                     },
                                     "runtimeConfiguration": {
                                         "secureData": {
@@ -734,10 +727,10 @@
                                         "body": "@outputs('Compose_windows_action')",
                                         "headers": {
                                             "Content-Type": "application/json",
-                                            "session": "@{body('Get_secret')?['value']}"
+                                            "session": "@{body('Get_API_Token')?['value']}"
                                         },
                                         "method": "POST",
-                                        "uri": "@parameters('TaniumActionsApi')"
+                                        "uri": "@uri(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumActionsPath')))"
                                     },
                                     "runtimeConfiguration": {
                                         "secureData": {
@@ -965,10 +958,10 @@
                                     "inputs": {
                                         "headers": {
                                             "Content-Type": "application/json",
-                                            "session": "@{body('Get_secret')?['value']}"
+                                            "session": "@{body('Get_API_Token')?['value']}"
                                         },
                                         "method": "GET",
-                                        "uri": "@{concat(parameters('TaniumPackagesByNameUrlFragment'), join(split(variables('macOsPackageName'), ' '), '%20'))}"
+                                        "uri": "@{concat(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumPackagesByNamePath')), join(split(variables('windowsPackageName'), ' '), '%20'))}"
                                     },
                                     "runtimeConfiguration": {
                                         "secureData": {
@@ -989,10 +982,10 @@
                                         "body": "@outputs('Compose_macOS_action')",
                                         "headers": {
                                             "Content-Type": "application/json",
-                                            "session": "@{body('Get_secret')?['value']}"
+                                            "session": "@{body('Get_API_Token')?['value']}"
                                         },
                                         "method": "POST",
-                                        "uri": "@parameters('TaniumActionsApi')"
+                                        "uri": "@uri(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumActionsPath')))"
                                     },
                                     "runtimeConfiguration": {
                                         "secureData": {
@@ -1460,11 +1453,11 @@
                                     "type": "Http",
                                     "description": "Get information about the incident hosts from Tanium.",
                                     "inputs": {
-                                        "uri": "@parameters('TaniumApiGatewayApi')",
+                                        "uri": "@uri(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumApiGatewayPath')))",
                                         "method": "POST",
                                         "headers": {
                                             "Content-Type": "application/json",
-                                            "session": "@{body('Get_secret')?['value']}"
+                                            "session": "@{body('Get_API_Token')?['value']}"
                                         },
                                         "body": {
                                             "query": "@variables('apiQuery')",
@@ -1508,11 +1501,11 @@
                                         "Requery_the_API_Gateway": {
                                             "type": "Http",
                                             "inputs": {
-                                                "uri": "@parameters('TaniumApiGatewayApi')",
+                                                "uri": "@uri(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumApiGatewayPath')))",
                                                 "method": "POST",
                                                 "headers": {
                                                     "Content-Type": "application/json",
-                                                    "session": "@{body('Get_secret')?['value']}"
+                                                    "session": "@{body('Get_API_Token')?['value']}"
                                                 },
                                                 "body": {
                                                     "query": "@variables('apiQuery')",
@@ -1767,11 +1760,11 @@
                                                 "Get_next_page": {
                                                     "type": "Http",
                                                     "inputs": {
-                                                        "uri": "@parameters('TaniumApiGatewayApi')",
+                                                        "uri": "@uri(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumApiGatewayPath')))",
                                                         "method": "POST",
                                                         "headers": {
                                                             "Content-Type": "application/json",
-                                                            "session": "@{body('Get_secret')?['value']}"
+                                                            "session": "@{body('Get_API_Token')?['value']}"
                                                         },
                                                         "body": {
                                                             "query": "@variables('apiQuery')",
@@ -1940,7 +1933,10 @@
                                 }
                             },
                             "runAfter": {
-                                "Get_secret": [
+                                "Get_API_Token": [
+                                    "SUCCEEDED"
+                                ],
+                                "Get_Server_Host": [
                                     "SUCCEEDED"
                                 ]
                             }
@@ -2102,11 +2098,11 @@
                                         "Get_action_result": {
                                             "type": "Http",
                                             "inputs": {
-                                                "uri": "@{concat(parameters('TaniumActionResultDataUrlFragment'), items('Collect_action_results_for_each_issued_action')?['id'])}",
+                                                "uri": "@{concat(concat('https://', body('Get_Server_Host')?['value'], parameters('TaniumActionResultPath')), items('Collect_action_results_for_each_issued_action')?['id'])}",
                                                 "method": "GET",
                                                 "headers": {
                                                     "Content-Type": "application/json",
-                                                    "session": "@{body('Get_secret')?['value']}"
+                                                    "session": "@{body('Get_API_Token')?['value']}"
                                                 }
                                             },
                                             "runtimeConfiguration": {
@@ -2584,7 +2580,7 @@
                                 ]
                             }
                         },
-                        "Get_secret": {
+                        "Get_API_Token": {
                             "type": "ApiConnection",
                             "inputs": {
                                 "host": {
@@ -2594,6 +2590,40 @@
                                 },
                                 "method": "get",
                                 "path": "/secrets/@{encodeURIComponent('TaniumApiToken')}/value"
+                            },
+                            "runtimeConfiguration": {
+                                "secureData": {
+                                    "properties": [
+                                        "inputs",
+                                        "outputs"
+                                    ]
+                                }
+                            },
+                            "runAfter": {
+                                "Initialize_API_Query": [
+                                    "Succeeded"
+                                ],
+                                "Initialize_endpoints_array": [
+                                    "Succeeded"
+                                ],
+                                "Initialize_API_Variables": [
+                                    "Succeeded"
+                                ],
+                                "Initialize_cursor": [
+                                    "Succeeded"
+                                ]
+                            }
+                        },
+                        "Get_Server_Host": {
+                            "type": "ApiConnection",
+                            "inputs": {
+                                "host": {
+                                    "connection": {
+                                        "name": "@parameters('$connections')['keyvault-1']['connectionId']"
+                                    }
+                                },
+                                "method": "get",
+                                "path": "/secrets/@{encodeURIComponent('TaniumServerHostname')}/value"
                             },
                             "runtimeConfiguration": {
                                 "secureData": {
@@ -2647,20 +2677,20 @@
                             }
                         }
                     },
-                    "TaniumActionsApi": {
-                        "value": "[variables('TaniumActionsApi')]"
+                    "TaniumActionsPath": {
+                        "value": "[variables('TaniumActionsPath')]"
                     },
-                    "TaniumAllComputersUrl": {
-                        "value": "[variables('TaniumAllComputersUrl')]"
+                    "TaniumAllComputersPath2": {
+                        "value": "[variables('TaniumAllComputersPath')]"
                     },
-                    "TaniumPackagesByNameUrlFragment": {
-                        "value": "[variables('TaniumPackagesByNameUrlFragment')]"
+                    "TaniumPackagesByNamePath": {
+                        "value": "[variables('TaniumPackagesByNamePath')]"
                     },
-                    "TaniumActionResultDataUrlFragment": {
-                        "value": "[variables('TaniumActionResultDataUrlFragment')]"
+                    "TaniumActionResultPath": {
+                        "value": "[variables('TaniumActionResultPath')]"
                     },
-                    "TaniumApiGatewayApi": {
-                        "value": "[variables('TaniumApiGatewayApi')]"
+                    "TaniumApiGatewayPath": {
+                        "value": "[variables('TaniumApiGatewayPath')]"
                     }
                 }
             }


### PR DESCRIPTION
# What
Each of our playbooks _(which are how Sentinel automates actions on incidents using [Azure Logic Apps](https://learn.microsoft.com/en-us/azure/logic-apps/logic-apps-overview))_ leverages Tanium's API to interact with the Tanium Server.

For this upcoming release we updated all of our Sentinel Playbooks to use an [Azure Key Vault](https://learn.microsoft.com/en-us/azure/key-vault/general/basic-concepts) to access the API token. So this update is to also have the playbooks access the server host name for the Tanium server via the key vault as well.

Each of the 8 playbooks we have has been updated to use the key vault for this value.

In this case it meant
- Renaming the action that gets the API token to be a less generic name
- Removing the old string parameter from the playbook
- Adding an action to get the secret from the key vault for the tanium host
- Updating the actions that used the removed parameter to now use the result of the new key vault action

# Why
For release 3.2 of our Sentinel Integration we're addressing some security items. In this case, we are attempting to prevent a situation where a bad actor gets access to a user's Azure account and attempts to change the Tanium server host with their own server to access the API token.

By placing it in the key vault and settings the `input` for the actions that use it to `secure` the only way the user could edit the server host would be if they have `Key Vault Secrets Officer` role, which we would expect would not happen as customers should follow best practices using RBAC to secure secrets and prevent bad actors.

# Does it work?
It should, however at this time leadership has decided that we will first make the changes for the release and then conduct testing, rather than testing each playbook as we make changes. This is due to the work needed to automate testing being done as-can-be.

However, I did confirm that deploying the playbook via the custom deployment tool in azure did not render any errors, so it does deploy as expected, but as mentioned above the playbook run itself needs to be tested.

# How can someone else confirm these changes?
See above response.