### PR TITLE
feat(playbooks) Updated all playbooks to treat ServerHost as a secret

### DIFF
--- a/Solutions/Tanium/Playbooks/Tanium-ComplyFindings/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-ComplyFindings/azuredeploy.json
@@ -62,8 +62,8 @@
             }
         },
         "TaniumServerHostname": {
-            "defaultValue": "<customerName>-api.cloud.tanium.com",
-            "type": "string",
+            "defaultValue": "",
+            "type": "securestring",
             "metadata": {
                 "description": "The hostname for your Tanium server's API. For cloud customers use <customerName>-api.cloud.tanium.com. For on-prem use the hostname of your server."
             }

--- a/Solutions/Tanium/Playbooks/Tanium-GeneralHostInfo/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-GeneralHostInfo/azuredeploy.json
@@ -59,10 +59,10 @@
             "metadata": {
                 "description": "The resource group name for the existing Azure Integration Account"
             }
-        },       
+        },
         "TaniumServerHostname": {
-            "defaultValue": "<customerName>-api.cloud.tanium.com",
-            "type": "String",
+            "defaultValue": "",
+            "type": "securestring",
             "metadata": {
                 "description": "The hostname for your Tanium server's API. For cloud customers use <customerName>-api.cloud.tanium.com. For on-prem use the hostname of your server."
             }
@@ -94,14 +94,14 @@
             "location": "[resourceGroup().location]",
             "kind": "V1",
             "properties": {
-                "displayName": "[parameters('KeyVaultConnectionName')]",                
+                "displayName": "[parameters('KeyVaultConnectionName')]",
                 "customParameterValues": {},
-                "api": {                    
+                "api": {
                     "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/keyvault')]"
                 },
                 "parameterValueType": "Alternative",
-                "alternativeParameterValues": {  
-                    "vaultName": "[parameters('KeyVaultName')]"  
+                "alternativeParameterValues": {
+                    "vaultName": "[parameters('KeyVaultName')]"
                 }
             }
         },

--- a/Solutions/Tanium/Playbooks/Tanium-MSDefenderHealth/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-MSDefenderHealth/azuredeploy.json
@@ -58,8 +58,8 @@
             }
         },
         "TaniumServerHostname": {
-            "defaultValue": "<customerName>-api.cloud.tanium.com",
-            "type": "String",
+            "defaultValue": "",
+            "type": "securestring",
             "metadata": {
                 "description": "The hostname for your Tanium server's API. For cloud customers use <customerName>-api.cloud.tanium.com. For on-prem use the hostname of your server."
             }

--- a/Solutions/Tanium/Playbooks/Tanium-QuarantineHosts/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-QuarantineHosts/azuredeploy.json
@@ -59,8 +59,8 @@
             }
         },
         "TaniumServerHostname": {
-            "defaultValue": "<customerName>-api.cloud.tanium.com",
-            "type": "String",
+            "defaultValue": "",
+            "type": "securestring",
             "metadata": {
                 "description": "The hostname for your Tanium server's API. For cloud customers use <customerName>-api.cloud.tanium.com. For on-prem use the hostname of your server."
             }

--- a/Solutions/Tanium/Playbooks/Tanium-ResolveThreatResponseAlert/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-ResolveThreatResponseAlert/azuredeploy.json
@@ -59,8 +59,8 @@
       }
     },
     "TaniumServerHostname": {
-      "defaultValue": "hostname",
-      "type": "String",
+      "defaultValue": "",
+      "type": "securestring",
       "metadata": {
         "description": "The hostname for your Tanium server e.g. tanium.example.com"
       }

--- a/Solutions/Tanium/Playbooks/Tanium-SCCMClientHealth/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-SCCMClientHealth/azuredeploy.json
@@ -58,8 +58,8 @@
             }
         },
         "TaniumServerHostname": {
-            "defaultValue": "<customerName>-api.cloud.tanium.com",
-            "type": "String",
+            "defaultValue": "",
+            "type": "securestring",
             "metadata": {
                 "description": "The hostname for your Tanium server's API. For cloud customers use <customerName>-api.cloud.tanium.com. For on-prem use the hostname of your server."
             }
@@ -128,7 +128,7 @@
                         "$connections": {
                             "defaultValue": {},
                             "type": "Object"
-                        },                       
+                        },
                         "TaniumApiGatewayApi": {
                             "type": "String"
                         }
@@ -692,10 +692,10 @@
                                         "method": "POST",
                                         "uri": "@parameters('TaniumApiGatewayApi')"
                                     },
-                                     "runAfter": {
+                                    "runAfter": {
                                         "Get_secret": [
                                             "SUCCEEDED"
-                                         ]
+                                        ]
                                     },
                                     "runtimeConfiguration": {
                                         "secureData": {
@@ -833,7 +833,7 @@
                                                 "outputs"
                                             ]
                                         }
-                                     }
+                                    }
                                 }
                             },
                             "runAfter": {
@@ -925,13 +925,13 @@
                                 "connectionId": "[resourceId('Microsoft.Web/connections', parameters('KeyVaultConnectionName'))]",
                                 "id": "[concat('/subscriptions/',subscription().subscriptionId, '/providers/Microsoft.Web/locations/',resourceGroup().location,'/managedApis/keyvault')]",
                                 "connectionProperties": {
-                                     "authentication": {
+                                    "authentication": {
                                         "type": "ManagedServiceIdentity"
                                     }
                                 }
                             }
                         }
-                    },                    
+                    },
                     "TaniumApiGatewayApi": {
                         "value": "[variables('TaniumApiGatewayApi')]"
                     }

--- a/Solutions/Tanium/Playbooks/Tanium-SecurityPatches/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-SecurityPatches/azuredeploy.json
@@ -59,8 +59,8 @@
             }
         },
         "TaniumServerHostname": {
-            "defaultValue": "<customerName>-api.cloud.tanium.com",
-            "type": "String",
+            "defaultValue": "",
+            "type": "securestring",
             "metadata": {
                 "description": "The hostname for your Tanium server's API. For cloud customers use <customerName>-api.cloud.tanium.com. For on-prem use the hostname of your server."
             }
@@ -1371,7 +1371,7 @@
                                 "connectionProperties": {
                                     "authentication": {
                                         "type": "ManagedServiceIdentity"
-                                     }
+                                    }
                                 }
                             }
                         }

--- a/Solutions/Tanium/Playbooks/Tanium-UnquarantineHosts/azuredeploy.json
+++ b/Solutions/Tanium/Playbooks/Tanium-UnquarantineHosts/azuredeploy.json
@@ -58,8 +58,8 @@
             }
         },
         "TaniumServerHostname": {
-            "defaultValue": "<customerName>-api.cloud.tanium.com",
-            "type": "String",
+            "defaultValue": "",
+            "type": "securestring",
             "metadata": {
                 "description": "The hostname for your Tanium server's API. For cloud customers use <customerName>-api.cloud.tanium.com. For on-prem use the hostname of your server."
             }


### PR DESCRIPTION
# What
Each of our playbooks _(which are how Sentinel automates actions on incidents using [Azure Logic Apps](https://learn.microsoft.com/en-us/azure/logic-apps/logic-apps-overview))_ leverages Tanium's API to interact with the Tanium Server.

For this upcoming release we wanted to ensure security practices within our playbooks. So we also wanted to treat the Tanium Server host as a [secure string](https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/data-types) to prevent visibility and some manipulation tactics that can be used in logic apps to change it as a way to obtain the API token.

Each of the 8 playbooks we have has been updated.

# Why
For release 3.2 of our Sentinel Integration we're addressing some security items. In this case, we are attempting to prevent a situation where a bad actor gets access to a user's Azure account and attempts to change the Tanium server host with their own server to access the API token.

By setting is as a `secureString` the only way the user could edit the server host would be if they have `Key Vault Secrets Officer` role, which we would expect would not happen as customers should follow best practices using RBAC to secure secrets and prevent bad actors.

# Does it work?
It should, however at this time leadership has decided that we will first make the changes for the release and then conduct testing, rather than testing each playbook as we make changes. This is due to the work needed to automate testing being done as-can-be.

However, I did confirm that deploying the playbook via the custom deployment tool in azure did not render any errors, so it does deploy as expected, but as mentioned above the playbook run itself needs to be tested.

# How can someone else confirm these changes?
See above response.