### PR TITLE
feat + fix(analytics rule) Enhanced incident names and fixed alert grouping

### DIFF
--- a/Solutions/Tanium/Analytic Rules/TaniumThreatResponseAlerts.yaml
+++ b/Solutions/Tanium/Analytic Rules/TaniumThreatResponseAlerts.yaml
@@ -32,6 +32,18 @@ entityMappings:
     fieldMappings:
       - identifier: Name
         columnName: TaniumTHRLabel
+customDetails:
+  IntelId: Intel_Id_d
+  TaniumAlertId: Alert_Id_g
+incidentConfiguration:
+  createIncident: true
+  groupingConfiguration:
+    enabled: false
+    reopenClosedIncident: false
+    lookbackDuration: PT5H
+    matchingMethod: AllEntities
+eventGroupingSettings:
+  aggregationKind: AlertPerResult
 alertDetailsOverride:
   alertDisplayNameFormat: "{{TaniumTHRLabel}}"
   alertDescriptionFormat: "Alert from Tanium Threat Response. GUID: {{Alert_Id_g}}; Computer Name: {{Computer_Name_s}}; IP: {{Computer_IP_s}}"

--- a/Solutions/Tanium/Analytic Rules/TaniumThreatResponseAlerts.yaml
+++ b/Solutions/Tanium/Analytic Rules/TaniumThreatResponseAlerts.yaml
@@ -32,5 +32,8 @@ entityMappings:
     fieldMappings:
       - identifier: Name
         columnName: TaniumTHRLabel
+alertDetailsOverride:
+  alertDisplayNameFormat: "{{TaniumTHRLabel}}"
+  alertDescriptionFormat: "Alert from Tanium Threat Response. GUID: {{Alert_Id_g}}; Computer Name: {{Computer_Name_s}}; IP: {{Computer_IP_s}}"
 version: 1.1.0
 kind: Scheduled


### PR DESCRIPTION
# What
- Enhanced the incident that are created by this rule so the names are descriptive and specific rather than all having the same name
- Fixed the issue where the alerts were being grouped

# Why
- A bunch of incidents with the same name isn't helpful and doesn't make it easy to navigate the list of incidents
- Since the intention of this analytics rule is to be able to easily resolve Tanium Threat Response Alerts, then we should have a 1-to-1 relationship between Tanium THR Alerts and Sentinel Incidents

# Does it work?
- Yes, I published the rule to a workspace and then generated some incidents and the name displayed as expected
- Yes, I published the rule to a workspace and then generated some incidents and ensured that the alerts were no longer being grouped
See my attached screenshots
<img width="2018" height="643" alt="image" src="https://github.com/user-attachments/assets/99727fc7-ed55-40c2-97bc-b3713e57bb44" />

<img width="2199" height="726" alt="image" src="https://github.com/user-attachments/assets/919feb85-3915-43f0-97c7-624c0720056c" />


# How can someone else confirm these changes?
1. Create the connection in the Connect Module to send Tanium THR alerts to an Azure Log Analytics Workspace
1. Confirm that the data is being pushed to the workspace
1. See the Tanium Wiki for how to build and publish the solution to the workspace
1. Wait for a threat response alert to fire and then check the name and the source log analytics data to confirm they are no longer being grouped