### PR TITLE
Fix Data Connectors link in Tanium Workbook README

### DIFF
--- a/Solutions/Tanium/Data Connectors/connect-module-connections.json
+++ b/Solutions/Tanium/Data Connectors/connect-module-connections.json
@@ -1,5 +1,184 @@
 [
     {
+        "name": "Sentinel - Comply Compliance Findings (Azure Monitor)",
+        "description": null,
+        "minimumPassPercentage": 0,
+        "logLevel": 30,
+        "tempLogLevel": 30,
+        "tempLogLevelRuns": 0,
+        "schedule": "0 0 * * *",
+        "scheduleTimeZone": "UTC",
+        "moduleCallbackUri": null,
+        "maxOldSpaceSize": 1,
+        "streams": [
+            {
+                "route": "/v1/sources/pluginConfigurations/comply/findings-source",
+                "arguments": {
+                    "config": {
+                        "type": "Compliance",
+                        "queryTimeoutSeconds": 120,
+                        "batchSize": 5000,
+                        "testCacheSize": 100,
+                        "reportName": "None",
+                        "createdWithVersion": "4.11.0"
+                    },
+                    "module": "comply",
+                    "plugin": "findings-source",
+                    "type": "sources",
+                    "destinationType": null,
+                    "name": "comply-findings-source-664ca099-ab3a-4eba-bc5e-13b886e41458"
+                }
+            },
+            {
+                "route": "/v1/formats/columns",
+                "arguments": {
+                    "columns": [
+                        {
+                            "checked": true,
+                            "name": "Computer Name",
+                            "renameTo": "ComputerName",
+                            "type": "source",
+                            "valueType": "Unmodified",
+                            "referenceColumnNames": [],
+                            "value": null,
+                            "hint": null,
+                            "defaultValue": null,
+                            "formatString": null
+                        },
+                        {
+                            "checked": true,
+                            "name": "IP Address",
+                            "renameTo": "IPAddress",
+                            "type": "source",
+                            "valueType": "Unmodified",
+                            "referenceColumnNames": [],
+                            "value": null,
+                            "hint": null,
+                            "defaultValue": null,
+                            "formatString": null
+                        },
+                        {
+                            "checked": true,
+                            "name": "Operating System Generation",
+                            "renameTo": "OperatingSystemGeneration",
+                            "type": "source",
+                            "valueType": "Unmodified",
+                            "referenceColumnNames": [],
+                            "value": null,
+                            "hint": null,
+                            "defaultValue": null,
+                            "formatString": null
+                        },
+                        {
+                            "checked": true,
+                            "name": "Rule",
+                            "renameTo": "Rule",
+                            "type": "source",
+                            "valueType": "Unmodified",
+                            "referenceColumnNames": [],
+                            "value": null,
+                            "hint": null,
+                            "defaultValue": null,
+                            "formatString": null
+                        },
+                        {
+                            "checked": true,
+                            "name": "Rule ID",
+                            "renameTo": "RuleID",
+                            "type": "source",
+                            "valueType": "Unmodified",
+                            "referenceColumnNames": [],
+                            "value": null,
+                            "hint": null,
+                            "defaultValue": null,
+                            "formatString": null
+                        },
+                        {
+                            "checked": true,
+                            "name": "Standard",
+                            "renameTo": "Standard",
+                            "type": "source",
+                            "valueType": "Unmodified",
+                            "referenceColumnNames": [],
+                            "value": null,
+                            "hint": null,
+                            "defaultValue": null,
+                            "formatString": null
+                        },
+                        {
+                            "checked": true,
+                            "name": "Profile",
+                            "renameTo": "Profile",
+                            "type": "source",
+                            "valueType": "Unmodified",
+                            "referenceColumnNames": [],
+                            "value": null,
+                            "hint": null,
+                            "defaultValue": null,
+                            "formatString": null
+                        },
+                        {
+                            "checked": true,
+                            "name": "Version",
+                            "renameTo": "Version",
+                            "type": "source",
+                            "valueType": "Unmodified",
+                            "referenceColumnNames": [],
+                            "value": null,
+                            "hint": null,
+                            "defaultValue": null,
+                            "formatString": null
+                        },
+                        {
+                            "checked": true,
+                            "name": "Status Category",
+                            "renameTo": "StatusCategory",
+                            "type": "source",
+                            "valueType": "Unmodified",
+                            "referenceColumnNames": [],
+                            "value": null,
+                            "hint": null,
+                            "defaultValue": null,
+                            "formatString": null
+                        }
+                    ]
+                }
+            },
+            {
+                "route": "/v1/formats/stringifies",
+                "arguments": {
+                    "surroundWithSource": false,
+                    "enhancedJson": false,
+                    "rowSeparator": "\\n",
+                    "valueEscape": "",
+                    "valueEscapeReplace": "",
+                    "generateDocument": true
+                }
+            },
+            {
+                "route": "/v1/destinations/pluginConfigurations/connect/logs-ingestion-destination",
+                "arguments": {
+                    "config": {
+                        "batchSize": 500,
+                        "name": "Sentinel - Comply Compliance Findings",
+                        "tenantId": "{{TenantId}}",
+                        "clientId": "{{ClientId}}",
+                        "clientSecret": "{{ClientSecret}}",
+                        "ingestionEndpoint": "{{IngestionEndpoint}}",
+                        "dcrImmutableId": "{{DcrImmutableId}}",
+                        "streamName": "Custom-TaniumComplyCompliance"
+                    },
+                    "module": "connect",
+                    "plugin": "logs-ingestion-destination",
+                    "type": "destinations",
+                    "destinationType": null,
+                    "name": "Sentinel - Compliance Findings (Azure Monitor)"
+                }
+            }
+        ],
+        "destinationType": "logs-ingestion-destination"
+    },
+    {
         "name": "Sentinel - Comply Vulnerabilities (Azure Monitor)",
         "description": "Native Sentinel Comply Vulnerabilities from Tanium compliance assessment.",
         "minimumPassPercentage": 0,

--- a/Solutions/Tanium/Workbooks/README.md
+++ b/Solutions/Tanium/Workbooks/README.md
@@ -10,7 +10,7 @@ The Tanium Workbook contains 20+ visualizations across 5 tabs (Threat Response, 
 
 To populate that data for the Tanium Workbook you'll need to create connections using the Tanium Connect Module in your Tanium Server.
 
-See [Data Connectors](../Data$20Connectors) for instructions to setup the necessary connections.
+See [Data Connectors](../Data%20Connectors) for instructions to setup the necessary connections.
 
 ## Help
 


### PR DESCRIPTION
## What
Corrects the `Data Connectors` link in `Solutions/Tanium/Workbooks/README.md` so it resolves properly.

## Why
The URL used `$20` instead of the correct `%20` to encode the space in `Data Connectors`, breaking the link to the folder that documents how to set up the connections needed to populate the Tanium Workbook.

## How
Replaced `Data$20Connectors` with `Data%20Connectors` in the relative link.